### PR TITLE
Add category edit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ It's a basic file format. Every command must be on it's own line empty lines are
 | `Page`                 | Creates a new page |
 | `--`                   | Inserts a horizontal rule and resets columns |
 
+## Editing
+
+The `/edit` page allows updating the entire bookmark file.
+Each category heading on the index page now also includes a small
+`edit` link that opens `/editCategory`. This page shows only the selected
+category text and saves changes back to your bookmarks without touching
+other sections. Edits check the file's SHA so you'll get an error if it
+changed while you were editing.
+
 ![img.png](media/img.png)
 
 ![img_1.png](media/img_1.png)

--- a/bookmarkActionHandlers.go
+++ b/bookmarkActionHandlers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/sessions"
 	"golang.org/x/oauth2"
 	"net/http"
+	"strconv"
 )
 
 func BookmarksEditSaveAction(w http.ResponseWriter, r *http.Request) error {
@@ -15,13 +16,22 @@ func BookmarksEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 	token, _ := session.Values["Token"].(*oauth2.Token)
 	branch := r.PostFormValue("branch")
 	ref := r.PostFormValue("ref")
+	sha := r.PostFormValue("sha")
 
 	login := ""
 	if githubUser != nil && githubUser.Login != nil {
 		login = *githubUser.Login
 	}
 
-	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, text); err != nil {
+	_, curSha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	if sha != "" && curSha != sha {
+		return fmt.Errorf("bookmark modified concurrently")
+	}
+
+	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, text, curSha); err != nil {
 		return fmt.Errorf("updateBookmark error: %w", err)
 	}
 	return nil
@@ -41,6 +51,43 @@ func BookmarksEditCreateAction(w http.ResponseWriter, r *http.Request) error {
 
 	if err := CreateBookmarks(r.Context(), login, token, branch, text); err != nil {
 		return fmt.Errorf("crateBookmark error: %w", err)
+	}
+	return nil
+}
+
+func CategoryEditSaveAction(w http.ResponseWriter, r *http.Request) error {
+	text := r.PostFormValue("text")
+	idxStr := r.URL.Query().Get("index")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return fmt.Errorf("invalid index: %w", err)
+	}
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*github.User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	branch := r.PostFormValue("branch")
+	ref := r.PostFormValue("ref")
+	sha := r.PostFormValue("sha")
+
+	login := ""
+	if githubUser != nil && githubUser.Login != nil {
+		login = *githubUser.Login
+	}
+
+	currentBookmarks, curSha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	if sha != "" && curSha != sha {
+		return fmt.Errorf("bookmark modified concurrently")
+	}
+	updated, err := ReplaceCategoryByIndex(currentBookmarks, idx, text)
+	if err != nil {
+		return fmt.Errorf("ReplaceCategory: %w", err)
+	}
+
+	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, updated, curSha); err != nil {
+		return fmt.Errorf("updateBookmark error: %w", err)
 	}
 	return nil
 }

--- a/bookmarkCategoryEdit.go
+++ b/bookmarkCategoryEdit.go
@@ -1,0 +1,77 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExtractCategoryByIndex returns the category text for the nth category (0 based)
+func ExtractCategoryByIndex(bookmarks string, index int) (string, error) {
+	lines := strings.Split(bookmarks, "\n")
+	currentIndex := -1
+	start := -1
+	end := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), "category:") {
+			currentIndex++
+			if currentIndex == index {
+				start = i
+				for j := i + 1; j <= len(lines); j++ {
+					if j == len(lines) {
+						end = j
+						break
+					}
+					t := strings.TrimSpace(lines[j])
+					if strings.HasPrefix(strings.ToLower(t), "category:") || strings.EqualFold(t, "column") || strings.EqualFold(t, "page") || t == "--" {
+						end = j
+						break
+					}
+				}
+				break
+			}
+		}
+	}
+	if start == -1 || end == -1 {
+		return "", fmt.Errorf("category index %d not found", index)
+	}
+	return strings.Join(lines[start:end], "\n"), nil
+}
+
+// ReplaceCategoryByIndex replaces the nth category with newText
+func ReplaceCategoryByIndex(bookmarks string, index int, newText string) (string, error) {
+	lines := strings.Split(bookmarks, "\n")
+	currentIndex := -1
+	start := -1
+	end := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), "category:") {
+			currentIndex++
+			if currentIndex == index {
+				start = i
+				for j := i + 1; j <= len(lines); j++ {
+					if j == len(lines) {
+						end = j
+						break
+					}
+					t := strings.TrimSpace(lines[j])
+					if strings.HasPrefix(strings.ToLower(t), "category:") || strings.EqualFold(t, "column") || strings.EqualFold(t, "page") || t == "--" {
+						end = j
+						break
+					}
+				}
+				break
+			}
+		}
+	}
+	if start == -1 || end == -1 {
+		return "", fmt.Errorf("category index %d not found", index)
+	}
+	var result []string
+	result = append(result, lines[:start]...)
+	newLines := strings.Split(newText, "\n")
+	result = append(result, newLines...)
+	result = append(result, lines[end:]...)
+	return strings.Join(result, "\n"), nil
+}

--- a/bookmarkCategoryEdit_test.go
+++ b/bookmarkCategoryEdit_test.go
@@ -1,0 +1,45 @@
+package gobookmarks
+
+import "testing"
+
+const testBookmarkText = `Category: A
+http://a.com a
+Column
+Category: B
+http://b.com b
+`
+
+func TestExtractCategoryByIndex(t *testing.T) {
+	got, err := ExtractCategoryByIndex(testBookmarkText, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "Category: B\nhttp://b.com b\n"
+	if got != expected {
+		t.Fatalf("expected %q got %q", expected, got)
+	}
+}
+
+func TestExtractCategoryByIndexError(t *testing.T) {
+	if _, err := ExtractCategoryByIndex(testBookmarkText, 5); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReplaceCategoryByIndex(t *testing.T) {
+	newSection := "Category: B\nhttp://new.com n"
+	updated, err := ReplaceCategoryByIndex(testBookmarkText, 1, newSection)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "Category: A\nhttp://a.com a\nColumn\n" + newSection
+	if updated != expected {
+		t.Fatalf("expected %q got %q", expected, updated)
+	}
+}
+
+func TestReplaceCategoryByIndexError(t *testing.T) {
+	if _, err := ReplaceCategoryByIndex(testBookmarkText, 3, "foo"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/bookmarkProcessor.go
+++ b/bookmarkProcessor.go
@@ -12,6 +12,7 @@ type BookmarkEntry struct {
 type BookmarkCategory struct {
 	Name    string
 	Entries []*BookmarkEntry
+	Index   int
 }
 
 type BookmarkColumn struct {
@@ -31,11 +32,14 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 	lines := strings.Split(bookmarks, "\n")
 	var result = []*BookmarkPage{{Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}}}
 	var currentCategory *BookmarkCategory
+	idx := 0
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.EqualFold(line, "Page") {
 			if currentCategory != nil {
+				currentCategory.Index = idx
+				idx++
 				lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
 				lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
 				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
@@ -46,6 +50,8 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 		}
 		if line == "--" {
 			if currentCategory != nil {
+				currentCategory.Index = idx
+				idx++
 				lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
 				lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
 				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
@@ -58,6 +64,8 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 		}
 		if strings.EqualFold(line, "column") {
 			if currentCategory != nil {
+				currentCategory.Index = idx
+				idx++
 				lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
 				lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
 				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
@@ -76,6 +84,8 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 			if currentCategory == nil {
 				currentCategory = &BookmarkCategory{Name: categoryName}
 			} else if currentCategory.Name != "" {
+				currentCategory.Index = idx
+				idx++
 				lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
 				lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
 				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
@@ -95,6 +105,8 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 	}
 
 	if currentCategory != nil && currentCategory.Name != "" {
+		currentCategory.Index = idx
+		idx++
 		lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
 		lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
 		lastColumn.Categories = append(lastColumn.Categories, currentCategory)

--- a/categoryEditHandlers.go
+++ b/categoryEditHandlers.go
@@ -1,0 +1,55 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"github.com/google/go-github/v55/github"
+	"github.com/gorilla/sessions"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strconv"
+)
+
+func EditCategoryPage(w http.ResponseWriter, r *http.Request) error {
+	idxStr := r.URL.Query().Get("index")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil {
+		return fmt.Errorf("invalid index: %w", err)
+	}
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*github.User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	ref := r.URL.Query().Get("ref")
+
+	login := ""
+	if githubUser != nil && githubUser.Login != nil {
+		login = *githubUser.Login
+	}
+
+	bookmarks, sha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	text, err := ExtractCategoryByIndex(bookmarks, idx)
+	if err != nil {
+		return fmt.Errorf("ExtractCategory: %w", err)
+	}
+
+	data := struct {
+		*CoreData
+		Error string
+		Index int
+		Text  string
+		Sha   string
+	}{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Error:    r.URL.Query().Get("error"),
+		Index:    idx,
+		Text:     text,
+		Sha:      sha,
+	}
+
+	if err := GetCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "editCategory.gohtml", data); err != nil {
+		return fmt.Errorf("template: %w", err)
+	}
+	return nil
+}

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -74,6 +74,11 @@ func main() {
 	r.HandleFunc("/edit", runHandlerChain(BookmarksEditCreateAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Create"))
 	r.HandleFunc("/edit", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
+	r.HandleFunc("/editCategory", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
+	r.HandleFunc("/editCategory", runHandlerChain(EditCategoryPage)).Methods("GET").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/editCategory", runHandlerChain(CategoryEditSaveAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save"))
+	r.HandleFunc("/editCategory", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
+
 	r.HandleFunc("/history", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/history", runTemplate("history.gohtml")).Methods("GET").MatcherFunc(RequiresAnAccount())
 

--- a/templates/edit.gohtml
+++ b/templates/edit.gohtml
@@ -10,6 +10,7 @@
         <label for="branch">Branch</label>: <input id="branch" type="text" name="branch" value="{{ branchOrEditBranch }}" /><br>
         <input type=submit name="task" value="Save" /><br>
         <input type=hidden name="ref" value="{{ref}}" />
+        <input type=hidden name="sha" value="{{bookmarksSHA}}" />
     </form>
 
     <b><u>How to use this?</u></b><br>

--- a/templates/editCategory.gohtml
+++ b/templates/editCategory.gohtml
@@ -1,0 +1,13 @@
+{{ template "head" $ }}
+    {{ if $.Error }}
+        <p style="color: #FF0000">Error: {{ $.Error }}</p>
+    {{ end }}
+    <form method=post action="?index={{$.Index}}">
+        <label for="code">Category</label><br/>
+        <textarea id="code" name="text" rows="10" style="width: 90vw; height: 30vh;">{{$.Text}}</textarea><br>
+        <label for="branch">Branch</label>: <input id="branch" type="text" name="branch" value="{{ branchOrEditBranch }}" /><br>
+        <input type=submit name="task" value="Save" /><br>
+        <input type=hidden name="ref" value="{{ref}}" />
+        <input type=hidden name="sha" value="{{bookmarksSHA}}" />
+    </form>
+{{ template "tail" $ }}

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -15,7 +15,7 @@
                     <td>
                         {{- range .Categories }}
                             <ul  style="list-style-type: none;">
-                                <h2>{{ .Name }}</h2>
+                                <h2>{{ .Name }} <a href="/editCategory?index={{ .Index }}&ref={{ref}}" style="font-size: small;">edit</a></h2>
                                 {{- range .Entries }}
                                     <li>
                                         <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />


### PR DESCRIPTION
## Summary
- enable categories to carry an index so they can be referenced directly
- support editing a specific bookmark category
- add UI links to edit a category
- extend README with a description of category editing
- add unit tests for category extraction/replacement
- protect category and file edits against concurrent modification

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841026a14e0832f88e2e342de5f3446