### PR TITLE
Add syntax notes on edit pages

### DIFF
--- a/templates/edit.gohtml
+++ b/templates/edit.gohtml
@@ -13,11 +13,5 @@
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
     </form>
 
-    <b><u>How to use this?</u></b><br>
-    Simply. First edit your page using the keywords below then set it as your start page.<br>
-    "&lt;URL&gt; &lt;Name&gt; &lt;Newline&gt;" - Will create a link to URL with name, if you need to use a space make it %20 and use that.<br>
-    "Category: &lt;name&gt; &lt;Newline&gt;" - Creates a category named  &lt;name&gt;.<br />
-    "Column &lt;Newline&gt;" - Creates a new column.<br/>
-    "Page &lt;Newline&gt;" - Creates a new page.<br/>
-    "--" - Inserts a horizontal rule and resets the columns.
+    {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/editCategory.gohtml
+++ b/templates/editCategory.gohtml
@@ -10,4 +10,5 @@
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
     </form>
+    {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/editNotes.gohtml
+++ b/templates/editNotes.gohtml
@@ -1,0 +1,10 @@
+{{define "editNotes"}}
+    <b><u>How to use this?</u></b><br>
+    Simply edit your page using the keywords below then set it as your start page.<br>
+    "&lt;URL&gt; &lt;Name&gt; &lt;Newline&gt;" - Creates a link to URL with name, if you need spaces use %20.<br>
+    "Category: &lt;name&gt; &lt;Newline&gt;" - Creates a category named &lt;name&gt;.<br/>
+    "Column &lt;Newline&gt;" - Creates a new column.<br/>
+    "Page &lt;Newline&gt;" - Creates a new page.<br/>
+    "--" - Inserts a horizontal rule and resets the columns.<br>
+    <i>Each category heading on the index page has a pencil icon that links to /editCategory for quick edits. Changes are checked against the file SHA to prevent losing updates.</i>
+{{end}}


### PR DESCRIPTION
## Summary
- add `editNotes` partial that explains the bookmark syntax and edit notes
- include the new partial in both edit pages

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68411fa1c73c832fb3a913f0971f3660