### PR TITLE
Remove env file from packages

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,6 +54,22 @@ nfpms:
     release: 1
     section: default
     priority: extra
+    scripts:
+      postinstall: packaging/postinstall.sh
+    contents:
+      - src: packaging/systemd/gobookmarks.service
+        dst: /lib/systemd/system/gobookmarks.service
+        type: config
+      - src: packaging/rc.d/gobookmarks
+        dst: /usr/local/etc/rc.d/gobookmarks
+        type: config
+      - src: packaging/config.json
+        dst: /etc/gobookmarks/config.json
+        type: config
+        file_info:
+          mode: 0600
+          owner: gobookmarks
+          group: gobookmarks
 
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/README.md
+++ b/README.md
@@ -64,14 +64,17 @@ changed while you were editing.
 You can run this yourself. There is a docker version available under my github packages. There are also precompiled versions
 under the releases section of this git repo: https://github.com/arran4/StartHere/releases
 
-You will require 3 environment arguments:
+Configuration values can be supplied as environment variables, via a JSON configuration file or using command line arguments. Environment variables are the lowest priority, followed by the configuration file and finally command line arguments. If `/etc/gobookmarks/gobookmarks.env` exists it will be loaded before reading the environment.
 
-| Arg | Value                                                                                            |
-| --- |--------------------------------------------------------------------------------------------------|
-| `OAUTH2_CLIENT_ID` | The Client ID generated from setting up Oauth2 on github: https://github.com/settings/developers |
-| `OAUTH2_SECRET` | Secret ID  generated from setting up Oauth2 on github: https://github.com/settings/developers |
-| `EXTERNAL_URL` | The fully qualified URL that it is to accept connections from. Ie `http://localhost:8080`        |
+| Name | Description |
+| --- | --- |
+| `OAUTH2_CLIENT_ID` | OAuth2 client ID from <https://github.com/settings/developers> |
+| `OAUTH2_SECRET` | OAuth2 client secret from <https://github.com/settings/developers> |
+| `EXTERNAL_URL` | Fully qualified URL the service is reachable on, e.g. `http://localhost:8080` |
 | `GBM_CSS_COLUMNS` | If set (to any value) the `Column` keyword in your bookmarks will create CSS multi-column breaks rather than table cells. |
+
+You can place these settings in `/etc/gobookmarks/gobookmarks.env` as `KEY=VALUE` pairs and the service will load them automatically if the file exists.
+The release packages do not install this file; create it manually if you want to use environment-based settings.
 
 ## Oauth2 setup
 
@@ -83,4 +86,22 @@ Create an application, call it what ever you like. Set the Callback URL what eve
 Upload `logo.png` for the logo.
 
 Generate a secret key and use it for the environment variables with the Client Id.
+
+## Running as a Service
+
+The release packages include service files for both `systemd` and FreeBSD
+`rc.d`.  During installation these files can be copied to your system so the
+server starts automatically on boot.
+
+When installed from the release packages the service files pass
+`--config /etc/gobookmarks/config.json`. An example config file is included in
+the packages and is installed with permissions `0600` owned by the
+`gobookmarks` user.  The installation process creates this user automatically
+and both service files run the daemon as `gobookmarks`.
+
+### Docker
+
+The Docker image continues to work as before.  Mount `/data` if you need
+persistent storage and pass the same environment variables as listed above or
+mount a compatible `gobookmarks.env` file to `/etc/gobookmarks/gobookmarks.env`.
 

--- a/bookmarkAccess.go
+++ b/bookmarkAccess.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-github/v55/github"
 	"golang.org/x/oauth2"
 	"net/http"
-	"os"
 )
 
 var (
@@ -19,9 +18,8 @@ var (
 )
 
 func GetBookmarksRepoName() string {
-	ns := os.Getenv("GBM_NAMESPACE")
-	if ns != "" {
-		return fmt.Sprintf("MyBookmarks-%s", ns)
+	if Namespace != "" {
+		return fmt.Sprintf("MyBookmarks-%s", Namespace)
 	}
 	return "MyBookmarks"
 }

--- a/cmd/gobookmarks/flags.go
+++ b/cmd/gobookmarks/flags.go
@@ -1,0 +1,28 @@
+package main
+
+import "strconv"
+
+type stringFlag struct {
+	value string
+	set   bool
+}
+
+func (s *stringFlag) Set(v string) error { s.value = v; s.set = true; return nil }
+func (s *stringFlag) String() string     { return s.value }
+
+type boolFlag struct {
+	value bool
+	set   bool
+}
+
+func (b *boolFlag) Set(v string) error {
+	val, err := strconv.ParseBool(v)
+	if err != nil {
+		return err
+	}
+	b.value = val
+	b.set = true
+	return nil
+}
+
+func (b *boolFlag) String() string { return strconv.FormatBool(b.value) }

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	. "github.com/arran4/gobookmarks"
 	"github.com/arran4/gorillamuxlogic"
@@ -28,10 +29,10 @@ import (
 )
 
 var (
-	clientID     = os.Getenv("OAUTH2_CLIENT_ID")
-	clientSecret = os.Getenv("OAUTH2_SECRET")
-	externalUrl  = os.Getenv("EXTERNAL_URL")
-	redirectUrl  = fmt.Sprintf("%s/oauth2Callback", externalUrl)
+	clientID     string
+	clientSecret string
+	externalUrl  string
+	redirectUrl  string
 	version      = "dev"
 	commit       = "none"
 	date         = "unknown"
@@ -39,6 +40,77 @@ var (
 
 func init() {
 	log.SetFlags(log.Flags() | log.Lshortfile)
+}
+
+func main() {
+
+	envPath := os.Getenv("GOBM_ENV_FILE")
+	if envPath == "" {
+		envPath = "/etc/gobookmarks/gobookmarks.env"
+	}
+	if err := LoadEnvFile(envPath); err != nil {
+		log.Printf("unable to load env file %s: %v", envPath, err)
+	}
+
+	cfg := Config{
+		Oauth2ClientID: os.Getenv("OAUTH2_CLIENT_ID"),
+		Oauth2Secret:   os.Getenv("OAUTH2_SECRET"),
+		ExternalURL:    os.Getenv("EXTERNAL_URL"),
+		CssColumns:     os.Getenv("GBM_CSS_COLUMNS") != "",
+		Namespace:      os.Getenv("GBM_NAMESPACE"),
+	}
+
+	configPath := os.Getenv("GOBM_CONFIG_FILE")
+	if configPath == "" {
+		configPath = "/etc/gobookmarks/config.json"
+	}
+
+	var cfgFlag stringFlag
+	var idFlag stringFlag
+	var secretFlag stringFlag
+	var urlFlag stringFlag
+	var nsFlag stringFlag
+	var columnFlag boolFlag
+	flag.Var(&cfgFlag, "config", "path to config file")
+	flag.Var(&idFlag, "client-id", "OAuth2 client ID")
+	flag.Var(&secretFlag, "client-secret", "OAuth2 client secret")
+	flag.Var(&urlFlag, "external-url", "external URL")
+	flag.Var(&nsFlag, "namespace", "repository namespace")
+	flag.Var(&columnFlag, "css-columns", "use CSS columns")
+	flag.Parse()
+
+	if cfgFlag.set {
+		configPath = cfgFlag.value
+	}
+	if fileCfg, err := LoadConfigFile(configPath); err == nil {
+		MergeConfig(&cfg, fileCfg)
+	} else {
+		log.Printf("unable to load config file %s: %v", configPath, err)
+	}
+
+	if idFlag.set {
+		cfg.Oauth2ClientID = idFlag.value
+	}
+	if secretFlag.set {
+		cfg.Oauth2Secret = secretFlag.value
+	}
+	if urlFlag.set {
+		cfg.ExternalURL = urlFlag.value
+	}
+	if nsFlag.set {
+		cfg.Namespace = nsFlag.value
+	}
+	if columnFlag.set {
+		cfg.CssColumns = columnFlag.value
+	}
+
+	UseCssColumns = cfg.CssColumns
+	Namespace = cfg.Namespace
+	clientID = cfg.Oauth2ClientID
+	clientSecret = cfg.Oauth2Secret
+	externalUrl = cfg.ExternalURL
+	redirectUrl = fmt.Sprintf("%s/oauth2Callback", externalUrl)
+
 	SessionName = "gobookmarks"
 	SessionStore = sessions.NewCookieStore([]byte("random-key")) // TODO random key
 	Oauth2Config = &oauth2.Config{
@@ -48,9 +120,7 @@ func init() {
 		Scopes:       []string{"repo", "read:user", "user:email"},
 		Endpoint:     endpoints.GitHub,
 	}
-}
 
-func main() {
 	r := mux.NewRouter()
 
 	r.Use(UserAdderMiddleware)

--- a/config.go
+++ b/config.go
@@ -1,0 +1,82 @@
+package gobookmarks
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// Config holds runtime configuration values.
+type Config struct {
+	Oauth2ClientID string `json:"oauth2_client_id"`
+	Oauth2Secret   string `json:"oauth2_secret"`
+	ExternalURL    string `json:"external_url"`
+	CssColumns     bool   `json:"css_columns"`
+	Namespace      string `json:"namespace"`
+}
+
+// LoadConfigFile loads configuration from the given path if it exists.
+func LoadConfigFile(path string) (Config, error) {
+	var c Config
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return c, err
+	}
+	err = json.Unmarshal(data, &c)
+	return c, err
+}
+
+// MergeConfig copies values from src into dst if they are non-zero.
+func MergeConfig(dst *Config, src Config) {
+	if src.Oauth2ClientID != "" {
+		dst.Oauth2ClientID = src.Oauth2ClientID
+	}
+	if src.Oauth2Secret != "" {
+		dst.Oauth2Secret = src.Oauth2Secret
+	}
+	if src.ExternalURL != "" {
+		dst.ExternalURL = src.ExternalURL
+	}
+	if src.CssColumns {
+		dst.CssColumns = true
+	}
+	if src.Namespace != "" {
+		dst.Namespace = src.Namespace
+	}
+}
+
+// LoadEnvFile sets environment variables from the given file if they are not already defined.
+// Lines should be in KEY=VALUE format and may be commented with '#'.
+func LoadEnvFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		val := strings.TrimSpace(parts[1])
+		if os.Getenv(key) == "" {
+			os.Setenv(key, val)
+		}
+	}
+	return scanner.Err()
+}

--- a/packaging/config.json
+++ b/packaging/config.json
@@ -1,0 +1,7 @@
+{
+  "oauth2_client_id": "",
+  "oauth2_secret": "",
+  "external_url": "http://localhost:8080",
+  "css_columns": false,
+  "namespace": ""
+}

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+if ! id gobookmarks >/dev/null 2>&1; then
+    useradd --system --home /nonexistent --shell /usr/sbin/nologin gobookmarks
+fi
+chown gobookmarks:gobookmarks /etc/gobookmarks/config.json || true
+chmod 600 /etc/gobookmarks/config.json || true
+if [ -f /etc/gobookmarks/gobookmarks.env ]; then
+    chown gobookmarks:gobookmarks /etc/gobookmarks/gobookmarks.env || true
+    chmod 600 /etc/gobookmarks/gobookmarks.env || true
+fi

--- a/packaging/rc.d/gobookmarks
+++ b/packaging/rc.d/gobookmarks
@@ -1,0 +1,29 @@
+#!/bin/sh
+# PROVIDE: gobookmarks
+# REQUIRE: LOGIN NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="gobookmarks"
+rcvar=gobookmarks_enable
+
+: ${gobookmarks_enable:="NO"}
+: ${gobookmarks_config_file:="/etc/gobookmarks/config.json"}
+: ${gobookmarks_user:="gobookmarks"}
+: ${gobookmarks_env_file:="/etc/gobookmarks/gobookmarks.env"}
+
+command="/usr/local/bin/gobookmarks"
+command_args="--config ${gobookmarks_config_file}"
+pidfile="/var/run/${name}.pid"
+command_user="${gobookmarks_user}"
+
+if [ -f "${gobookmarks_env_file}" ]; then
+       set -a
+       . "${gobookmarks_env_file}"
+       set +a
+fi
+
+load_rc_config $name
+
+run_rc_command "$1"

--- a/packaging/systemd/gobookmarks.service
+++ b/packaging/systemd/gobookmarks.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Gobookmarks Service
+After=network.target
+
+[Service]
+Type=simple
+User=gobookmarks
+Group=gobookmarks
+EnvironmentFile=-/etc/gobookmarks/gobookmarks.env
+ExecStart=/usr/local/bin/gobookmarks --config /etc/gobookmarks/config.json
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/settings.go
+++ b/settings.go
@@ -1,5 +1,6 @@
 package gobookmarks
 
-import "os"
-
-var UseCssColumns = os.Getenv("GBM_CSS_COLUMNS") != ""
+var (
+	UseCssColumns bool
+	Namespace     string
+)


### PR DESCRIPTION
## Summary
- stop installing `gobookmarks.env`
- note in docs that packages don't ship the env file
- keep service loader for manually created env files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6841982bdf24832fb8c6d27e36cf69cf