### PR TITLE
Improve provider validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The release packages do not install this file; create it manually if you want to
 
 Use `--config <path>` or set `GOBM_CONFIG_FILE` to control which configuration file is loaded.
 
-The `--provider` command line flag or `GBM_PROVIDER` environment variable selects which git provider to use. By default the binary includes both GitHub and GitLab support. Use build tags `nogithub` or `nogitlab` to exclude either provider when building from source.
+The `--provider` command line flag or `GBM_PROVIDER` environment variable selects which git provider to use. By default the binary includes both GitHub and GitLab support. Use build tags `nogithub` or `nogitlab` to exclude either provider when building from source. If you specify an unknown provider the program will exit with an error listing the available options.
 
 Running `gobookmarks --version` will print the version information along with the list of compiled-in providers.
 Use `--dump-config` to print the final configuration after merging the environment,

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -76,7 +76,7 @@ func main() {
 	flag.Var(&secretFlag, "client-secret", "OAuth2 client secret")
 	flag.Var(&urlFlag, "external-url", "external URL")
 	flag.Var(&nsFlag, "namespace", "repository namespace")
-	flag.Var(&providerFlag, "provider", "git provider (github, gitlab)")
+	flag.Var(&providerFlag, "provider", fmt.Sprintf("git provider (%s)", strings.Join(ProviderNames(), ", ")))
 	flag.Var(&columnFlag, "css-columns", "use CSS columns")
 	flag.BoolVar(&versionFlag, "version", false, "show version")
 	flag.BoolVar(&dumpConfig, "dump-config", false, "print merged config and exit")
@@ -129,7 +129,9 @@ func main() {
 	externalUrl = cfg.ExternalURL
 
 	if cfg.Provider != "" {
-		SetProviderByName(cfg.Provider)
+		if !SetProviderByName(cfg.Provider) {
+			log.Fatalf("invalid provider %q. valid options: %s", cfg.Provider, strings.Join(ProviderNames(), ", "))
+		}
 	}
 
 	SessionName = "gobookmarks"

--- a/provider.go
+++ b/provider.go
@@ -54,10 +54,14 @@ func ProviderNames() []string {
 
 var ActiveProvider Provider
 
-func SetProviderByName(name string) {
+// SetProviderByName activates the named provider.
+// It returns true if the provider exists.
+func SetProviderByName(name string) bool {
 	if p, ok := providers[name]; ok {
 		ActiveProvider = p
+		return true
 	}
+	return false
 }
 
 func init() {


### PR DESCRIPTION
## Summary
- validate provider names and fail on invalid entries
- show available providers in the `--provider` flag help text
- document the new behaviour in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844084ce1b8832f8c28a3a7c72e985e