### PR TITLE
Add session build version checks

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -49,7 +49,7 @@ func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("exchange error: %w", err)
 	}
 
-	session, err := SessionStore.Get(r, SessionName)
+	session, err := getSession(w, r)
 	if err != nil {
 		return fmt.Errorf("session error: %w", err)
 	}
@@ -61,6 +61,7 @@ func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
 
 	session.Values["GithubUser"] = user
 	session.Values["Token"] = token
+	session.Values["version"] = version
 
 	if err := session.Save(r, w); err != nil {
 		log.Printf("Exchange error: %s", err)
@@ -73,7 +74,7 @@ func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
 func UserAdderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		// Get the session.
-		session, err := SessionStore.Get(request, SessionName)
+		session, err := getSession(writer, request)
 		if err != nil {
 			http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
 			return
@@ -82,4 +83,24 @@ func UserAdderMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(request.Context(), ContextValues("session"), session)
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})
+}
+
+func getSession(w http.ResponseWriter, r *http.Request) (*sessions.Session, error) {
+	session, err := SessionStore.Get(r, SessionName)
+	if err != nil {
+		return nil, err
+	}
+	if v, ok := session.Values["version"].(string); !ok || v != version {
+		session.Options.MaxAge = -1
+		if err := session.Save(r, w); err != nil {
+			return nil, err
+		}
+		session, err = SessionStore.New(r, SessionName)
+		if err != nil {
+			return nil, err
+		}
+		session.Values = make(map[interface{}]interface{})
+		session.IsNew = true
+	}
+	return session, nil
 }

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -397,6 +397,9 @@ func RequiresAnAccount() mux.MatcherFunc {
 				return false
 			}
 		}
+		if v, ok := session.Values["version"].(string); !ok || v != version {
+			return false
+		}
 		githubUser, ok := session.Values["GithubUser"].(*User)
 		return ok && githubUser != nil
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,39 @@
+package gobookmarks
+
+import (
+	"github.com/gorilla/sessions"
+	"net/http/httptest"
+	"testing"
+)
+
+// Test that getSession clears outdated sessions and returns a fresh one.
+func Test_getSessionClearsOldVersion(t *testing.T) {
+	SessionName = "testsession"
+	SessionStore = sessions.NewCookieStore([]byte("secret-key"))
+	version = "current"
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// create a session with an old version
+	s, _ := SessionStore.New(req, SessionName)
+	s.Values["version"] = "old"
+	s.Values["GithubUser"] = &User{Login: "old"}
+	if err := s.Save(req, w); err != nil {
+		t.Fatalf("save old session: %v", err)
+	}
+	cookie := w.Result().Cookies()[0]
+	req.AddCookie(cookie)
+
+	w = httptest.NewRecorder()
+	newSession, err := getSession(w, req)
+	if err != nil {
+		t.Fatalf("getSession: %v", err)
+	}
+	if len(newSession.Values) != 0 {
+		t.Fatalf("expected empty session, got %#v", newSession.Values)
+	}
+	if h := w.Header().Get("Set-Cookie"); h == "" {
+		t.Fatalf("expected Set-Cookie header to clear session")
+	}
+}


### PR DESCRIPTION
## Summary
- use the build `version` string in sessions instead of a constant
- mark sessions invalid when their stored version mismatches
- test that `getSession` clears old version values

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684421aff794832fbfd910aca196b0a3