### PR TITLE
Allow configurable title; mark dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Configuration values can be supplied as environment variables, via a JSON config
 | `GBM_CSS_COLUMNS` | If set (to any value) the `Column` keyword in your bookmarks will create CSS multi-column breaks rather than table cells. |
 | `GBM_PROVIDER` | Git provider to use (`github` or `gitlab`). Defaults to `github`. |
 | `GBM_NAMESPACE` | Optional suffix added to the bookmarks repository name. |
+| `GBM_TITLE` | Overrides the page title shown in the browser. |
 | `GOBM_ENV_FILE` | Path to a file of `KEY=VALUE` pairs loaded before the environment. Defaults to `/etc/gobookmarks/gobookmarks.env`. |
 | `GOBM_CONFIG_FILE` | Path to the JSON config file. If unset the program uses `$XDG_CONFIG_HOME/gobookmarks/config.json` or `$HOME/.config/gobookmarks/config.json` for normal users and `/etc/gobookmarks/config.json` when run as root. |
 
@@ -83,6 +84,7 @@ The release packages do not install this file; create it manually if you want to
 Use `--config <path>` or set `GOBM_CONFIG_FILE` to control which configuration file is loaded.
 
 The `--provider` command line flag or `GBM_PROVIDER` environment variable selects which git provider to use. By default the binary includes both GitHub and GitLab support. Use build tags `nogithub` or `nogitlab` to exclude either provider when building from source. If you specify an unknown provider the program will exit with an error listing the available options.
+The `--title` flag or `GBM_TITLE` environment variable sets the browser page title.
 
 Running `gobookmarks --version` will print the version information along with the list of compiled-in providers.
 Use `--dump-config` to print the final configuration after merging the environment,

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -57,6 +57,7 @@ func main() {
 		ExternalURL:    os.Getenv("EXTERNAL_URL"),
 		CssColumns:     os.Getenv("GBM_CSS_COLUMNS") != "",
 		Namespace:      os.Getenv("GBM_NAMESPACE"),
+		Title:          os.Getenv("GBM_TITLE"),
 		Provider:       os.Getenv("GBM_PROVIDER"),
 	}
 
@@ -67,6 +68,7 @@ func main() {
 	var secretFlag stringFlag
 	var urlFlag stringFlag
 	var nsFlag stringFlag
+	var titleFlag stringFlag
 	var providerFlag stringFlag
 	var columnFlag boolFlag
 	var versionFlag bool
@@ -76,6 +78,7 @@ func main() {
 	flag.Var(&secretFlag, "client-secret", "OAuth2 client secret")
 	flag.Var(&urlFlag, "external-url", "external URL")
 	flag.Var(&nsFlag, "namespace", "repository namespace")
+	flag.Var(&titleFlag, "title", "site title")
 	flag.Var(&providerFlag, "provider", fmt.Sprintf("git provider (%s)", strings.Join(ProviderNames(), ", ")))
 	flag.Var(&columnFlag, "css-columns", "use CSS columns")
 	flag.BoolVar(&versionFlag, "version", false, "show version")
@@ -109,6 +112,9 @@ func main() {
 	if nsFlag.set {
 		cfg.Namespace = nsFlag.value
 	}
+	if titleFlag.set {
+		cfg.Title = titleFlag.value
+	}
 	if columnFlag.set {
 		cfg.CssColumns = columnFlag.value
 	}
@@ -124,6 +130,7 @@ func main() {
 
 	UseCssColumns = cfg.CssColumns
 	Namespace = cfg.Namespace
+	SiteTitle = cfg.Title
 	clientID = cfg.Oauth2ClientID
 	clientSecret = cfg.Oauth2Secret
 	externalUrl = cfg.ExternalURL

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	ExternalURL    string `json:"external_url"`
 	CssColumns     bool   `json:"css_columns"`
 	Namespace      string `json:"namespace"`
+	Title          string `json:"title"`
 }
 
 // LoadConfigFile loads configuration from the given path if it exists.
@@ -49,6 +50,9 @@ func MergeConfig(dst *Config, src Config) {
 	}
 	if src.Namespace != "" {
 		dst.Namespace = src.Namespace
+	}
+	if src.Title != "" {
+		dst.Title = src.Title
 	}
 
 	if src.Provider != "" {

--- a/core.go
+++ b/core.go
@@ -27,9 +27,17 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 			login = githubUser.Login
 		}
 
+		title := SiteTitle
+		if title == "" {
+			title = "Arran4's Bookmarks Website"
+		}
+		if version == "dev" && !strings.HasPrefix(title, "dev: ") {
+			title = "dev: " + title
+		}
+
 		ctx := context.WithValue(request.Context(), ContextValues("coreData"), &CoreData{
 			UserRef: login,
-			Title:   "Arran4's Bookmarks Website",
+			Title:   title,
 		})
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})

--- a/packaging/config.json
+++ b/packaging/config.json
@@ -3,5 +3,6 @@
   "oauth2_secret": "",
   "external_url": "http://localhost:8080",
   "css_columns": false,
-  "namespace": ""
+  "namespace": "",
+  "title": ""
 }

--- a/settings.go
+++ b/settings.go
@@ -3,4 +3,5 @@ package gobookmarks
 var (
 	UseCssColumns bool
 	Namespace     string
+	SiteTitle     string
 )

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -1,7 +1,7 @@
 {{define "head"}}
 <html>
 	<head>
-		<title>{{$.Title}}</title>
+                <title>{{if eq (version) "dev"}}dev: {{end}}{{$.Title}}</title>
 		<style type="text/css">
         <!--
         @import url("/main.css");


### PR DESCRIPTION
## Summary
- allow configuration of the page title via env/config/CLI
- prefix the page title with `dev:` when running a dev build
- document new `GBM_TITLE` option and `--title` flag

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684426cfa0bc832f8ccb2091eed02427