### PR TITLE
Enable custom GitLab server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Configuration values can be supplied as environment variables, via a JSON config
 | `GBM_PROVIDER` | Git provider to use (`github` or `gitlab`). Defaults to `github`. |
 | `GBM_NAMESPACE` | Optional suffix added to the bookmarks repository name. |
 | `GBM_TITLE` | Overrides the page title shown in the browser. |
-| `GITLAB_SERVER` | Base URL for self-hosted GitLab, e.g. `https://gitlab.example.com` |
+| `GIT_SERVER` | Base URL for a self-hosted git provider, e.g. `https://gitlab.example.com` |
 | `GOBM_ENV_FILE` | Path to a file of `KEY=VALUE` pairs loaded before the environment. Defaults to `/etc/gobookmarks/gobookmarks.env`. |
 | `GOBM_CONFIG_FILE` | Path to the JSON config file. If unset the program uses `$XDG_CONFIG_HOME/gobookmarks/config.json` or `$HOME/.config/gobookmarks/config.json` for normal users and `/etc/gobookmarks/config.json` when run as root. |
 
@@ -86,7 +86,7 @@ Use `--config <path>` or set `GOBM_CONFIG_FILE` to control which configuration f
 
 The `--provider` command line flag or `GBM_PROVIDER` environment variable selects which git provider to use. By default the binary includes both GitHub and GitLab support. Use build tags `nogithub` or `nogitlab` to exclude either provider when building from source. If you specify an unknown provider the program will exit with an error listing the available options.
 The `--title` flag or `GBM_TITLE` environment variable sets the browser page title.
-Use `--gitlab-server` or `GITLAB_SERVER` to point the application at a self-hosted GitLab instance.
+Use `--git-server` or `GIT_SERVER` to point the application at a self-hosted git provider.
 
 Running `gobookmarks --version` will print the version information along with the list of compiled-in providers.
 Use `--dump-config` to print the final configuration after merging the environment,

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Configuration values can be supplied as environment variables, via a JSON config
 | `GBM_PROVIDER` | Git provider to use (`github` or `gitlab`). Defaults to `github`. |
 | `GBM_NAMESPACE` | Optional suffix added to the bookmarks repository name. |
 | `GBM_TITLE` | Overrides the page title shown in the browser. |
+| `GITLAB_SERVER` | Base URL for self-hosted GitLab, e.g. `https://gitlab.example.com` |
 | `GOBM_ENV_FILE` | Path to a file of `KEY=VALUE` pairs loaded before the environment. Defaults to `/etc/gobookmarks/gobookmarks.env`. |
 | `GOBM_CONFIG_FILE` | Path to the JSON config file. If unset the program uses `$XDG_CONFIG_HOME/gobookmarks/config.json` or `$HOME/.config/gobookmarks/config.json` for normal users and `/etc/gobookmarks/config.json` when run as root. |
 
@@ -85,6 +86,7 @@ Use `--config <path>` or set `GOBM_CONFIG_FILE` to control which configuration f
 
 The `--provider` command line flag or `GBM_PROVIDER` environment variable selects which git provider to use. By default the binary includes both GitHub and GitLab support. Use build tags `nogithub` or `nogitlab` to exclude either provider when building from source. If you specify an unknown provider the program will exit with an error listing the available options.
 The `--title` flag or `GBM_TITLE` environment variable sets the browser page title.
+Use `--gitlab-server` or `GITLAB_SERVER` to point the application at a self-hosted GitLab instance.
 
 Running `gobookmarks --version` will print the version information along with the list of compiled-in providers.
 Use `--dump-config` to print the final configuration after merging the environment,

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -59,6 +59,7 @@ func main() {
 		Namespace:      os.Getenv("GBM_NAMESPACE"),
 		Title:          os.Getenv("GBM_TITLE"),
 		Provider:       os.Getenv("GBM_PROVIDER"),
+		GitLabServer:   os.Getenv("GITLAB_SERVER"),
 	}
 
 	configPath := DefaultConfigPath()
@@ -70,6 +71,7 @@ func main() {
 	var nsFlag stringFlag
 	var titleFlag stringFlag
 	var providerFlag stringFlag
+	var gitlabServerFlag stringFlag
 	var columnFlag boolFlag
 	var versionFlag bool
 	var dumpConfig bool
@@ -80,6 +82,7 @@ func main() {
 	flag.Var(&nsFlag, "namespace", "repository namespace")
 	flag.Var(&titleFlag, "title", "site title")
 	flag.Var(&providerFlag, "provider", fmt.Sprintf("git provider (%s)", strings.Join(ProviderNames(), ", ")))
+	flag.Var(&gitlabServerFlag, "gitlab-server", "GitLab server base URL")
 	flag.Var(&columnFlag, "css-columns", "use CSS columns")
 	flag.BoolVar(&versionFlag, "version", false, "show version")
 	flag.BoolVar(&dumpConfig, "dump-config", false, "print merged config and exit")
@@ -118,6 +121,9 @@ func main() {
 	if columnFlag.set {
 		cfg.CssColumns = columnFlag.value
 	}
+	if gitlabServerFlag.set {
+		cfg.GitLabServer = gitlabServerFlag.value
+	}
 	if providerFlag.set {
 		cfg.Provider = providerFlag.value
 	}
@@ -131,6 +137,9 @@ func main() {
 	UseCssColumns = cfg.CssColumns
 	Namespace = cfg.Namespace
 	SiteTitle = cfg.Title
+	if cfg.GitLabServer != "" {
+		GitLabServer = cfg.GitLabServer
+	}
 	clientID = cfg.Oauth2ClientID
 	clientSecret = cfg.Oauth2Secret
 	externalUrl = cfg.ExternalURL

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -59,7 +59,7 @@ func main() {
 		Namespace:      os.Getenv("GBM_NAMESPACE"),
 		Title:          os.Getenv("GBM_TITLE"),
 		Provider:       os.Getenv("GBM_PROVIDER"),
-		GitLabServer:   os.Getenv("GITLAB_SERVER"),
+		GitServer:      os.Getenv("GIT_SERVER"),
 	}
 
 	configPath := DefaultConfigPath()
@@ -71,7 +71,7 @@ func main() {
 	var nsFlag stringFlag
 	var titleFlag stringFlag
 	var providerFlag stringFlag
-	var gitlabServerFlag stringFlag
+	var gitServerFlag stringFlag
 	var columnFlag boolFlag
 	var versionFlag bool
 	var dumpConfig bool
@@ -82,7 +82,7 @@ func main() {
 	flag.Var(&nsFlag, "namespace", "repository namespace")
 	flag.Var(&titleFlag, "title", "site title")
 	flag.Var(&providerFlag, "provider", fmt.Sprintf("git provider (%s)", strings.Join(ProviderNames(), ", ")))
-	flag.Var(&gitlabServerFlag, "gitlab-server", "GitLab server base URL")
+	flag.Var(&gitServerFlag, "git-server", "git provider base URL")
 	flag.Var(&columnFlag, "css-columns", "use CSS columns")
 	flag.BoolVar(&versionFlag, "version", false, "show version")
 	flag.BoolVar(&dumpConfig, "dump-config", false, "print merged config and exit")
@@ -121,8 +121,8 @@ func main() {
 	if columnFlag.set {
 		cfg.CssColumns = columnFlag.value
 	}
-	if gitlabServerFlag.set {
-		cfg.GitLabServer = gitlabServerFlag.value
+	if gitServerFlag.set {
+		cfg.GitServer = gitServerFlag.value
 	}
 	if providerFlag.set {
 		cfg.Provider = providerFlag.value
@@ -137,8 +137,8 @@ func main() {
 	UseCssColumns = cfg.CssColumns
 	Namespace = cfg.Namespace
 	SiteTitle = cfg.Title
-	if cfg.GitLabServer != "" {
-		GitLabServer = cfg.GitLabServer
+	if cfg.GitServer != "" {
+		GitServer = cfg.GitServer
 	}
 	clientID = cfg.Oauth2ClientID
 	clientSecret = cfg.Oauth2Secret

--- a/config.go
+++ b/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	CssColumns     bool   `json:"css_columns"`
 	Namespace      string `json:"namespace"`
 	Title          string `json:"title"`
-	GitLabServer   string `json:"gitlab_server"`
+	GitServer      string `json:"git_server"`
 }
 
 // LoadConfigFile loads configuration from the given path if it exists.
@@ -55,8 +55,8 @@ func MergeConfig(dst *Config, src Config) {
 	if src.Title != "" {
 		dst.Title = src.Title
 	}
-	if src.GitLabServer != "" {
-		dst.GitLabServer = src.GitLabServer
+	if src.GitServer != "" {
+		dst.GitServer = src.GitServer
 	}
 
 	if src.Provider != "" {

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	CssColumns     bool   `json:"css_columns"`
 	Namespace      string `json:"namespace"`
 	Title          string `json:"title"`
+	GitLabServer   string `json:"gitlab_server"`
 }
 
 // LoadConfigFile loads configuration from the given path if it exists.
@@ -53,6 +54,9 @@ func MergeConfig(dst *Config, src Config) {
 	}
 	if src.Title != "" {
 		dst.Title = src.Title
+	}
+	if src.GitLabServer != "" {
+		dst.GitLabServer = src.GitLabServer
 	}
 
 	if src.Provider != "" {

--- a/packaging/config.json
+++ b/packaging/config.json
@@ -4,5 +4,6 @@
   "external_url": "http://localhost:8080",
   "css_columns": false,
   "namespace": "",
-  "title": ""
+  "title": "",
+  "gitlab_server": "https://gitlab.com"
 }

--- a/packaging/config.json
+++ b/packaging/config.json
@@ -5,5 +5,5 @@
   "css_columns": false,
   "namespace": "",
   "title": "",
-  "gitlab_server": "https://gitlab.com"
+  "git_server": "https://gitlab.com"
 }

--- a/provider_gitlab.go
+++ b/provider_gitlab.go
@@ -6,11 +6,16 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	gitlab "github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
 )
 
+// GitLabProvider implements Provider for GitLab.
+//
+// The GitLab server URL can be overridden using the GitLabServer variable
+// defined in settings.go.
 type GitLabProvider struct{}
 
 func init() { RegisterProvider(GitLabProvider{}) }
@@ -18,20 +23,28 @@ func init() { RegisterProvider(GitLabProvider{}) }
 func (GitLabProvider) Name() string { return "gitlab" }
 
 func (GitLabProvider) OAuth2Config(clientID, clientSecret, redirectURL string) *oauth2.Config {
+	server := strings.TrimRight(GitLabServer, "/")
+	if server == "" {
+		server = "https://gitlab.com"
+	}
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		RedirectURL:  redirectURL,
 		Scopes:       []string{"api"},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  "https://gitlab.com/oauth/authorize",
-			TokenURL: "https://gitlab.com/oauth/token",
+			AuthURL:  server + "/oauth/authorize",
+			TokenURL: server + "/oauth/token",
 		},
 	}
 }
 
 func (GitLabProvider) client(token *oauth2.Token) (*gitlab.Client, error) {
-	return gitlab.NewOAuthClient(token.AccessToken)
+	server := GitLabServer
+	if server == "" {
+		server = "https://gitlab.com"
+	}
+	return gitlab.NewOAuthClient(token.AccessToken, gitlab.WithBaseURL(server))
 }
 
 func (GitLabProvider) CurrentUser(ctx context.Context, token *oauth2.Token) (*User, error) {

--- a/provider_gitlab.go
+++ b/provider_gitlab.go
@@ -14,7 +14,7 @@ import (
 
 // GitLabProvider implements Provider for GitLab.
 //
-// The GitLab server URL can be overridden using the GitLabServer variable
+// The GitLab server URL can be overridden using the GitServer variable
 // defined in settings.go.
 type GitLabProvider struct{}
 
@@ -23,7 +23,7 @@ func init() { RegisterProvider(GitLabProvider{}) }
 func (GitLabProvider) Name() string { return "gitlab" }
 
 func (GitLabProvider) OAuth2Config(clientID, clientSecret, redirectURL string) *oauth2.Config {
-	server := strings.TrimRight(GitLabServer, "/")
+	server := strings.TrimRight(GitServer, "/")
 	if server == "" {
 		server = "https://gitlab.com"
 	}
@@ -40,7 +40,7 @@ func (GitLabProvider) OAuth2Config(clientID, clientSecret, redirectURL string) *
 }
 
 func (GitLabProvider) client(token *oauth2.Token) (*gitlab.Client, error) {
-	server := GitLabServer
+	server := GitServer
 	if server == "" {
 		server = "https://gitlab.com"
 	}

--- a/settings.go
+++ b/settings.go
@@ -4,4 +4,5 @@ var (
 	UseCssColumns bool
 	Namespace     string
 	SiteTitle     string
+	GitLabServer  string = "https://gitlab.com"
 )

--- a/settings.go
+++ b/settings.go
@@ -4,5 +4,5 @@ var (
 	UseCssColumns bool
 	Namespace     string
 	SiteTitle     string
-	GitLabServer  string = "https://gitlab.com"
+	GitServer     string = "https://gitlab.com"
 )


### PR DESCRIPTION
## Summary
- allow custom GitLab server URL
- support `--gitlab-server` / `GITLAB_SERVER` and config.json

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684432b4c344832fb867933efab29997