### PR TITLE
Add page links and tab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It's a basic file format. Every command must be on it's own line empty lines are
 | `<Link> <Name>`        | Will create a link to `<Link>` with the display name `<Name>` |
 | `Column`               | Will create a column                                         |
 | `Page`                 | Creates a new page |
+| `Tab: <name>`          | Starts a new named tab (switch using `?tab=<name>`) |
 | `--`                   | Inserts a horizontal rule and resets columns |
 
 ## Editing

--- a/bookmarkProcessor.go
+++ b/bookmarkProcessor.go
@@ -26,16 +26,31 @@ type BookmarkBlock struct {
 
 type BookmarkPage struct {
 	Blocks []*BookmarkBlock
+	Tab    string
 }
 
 func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 	lines := strings.Split(bookmarks, "\n")
 	var result = []*BookmarkPage{{Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}}}
 	var currentCategory *BookmarkCategory
+	currentTab := ""
 	idx := 0
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(line), "tab:") {
+			if currentCategory != nil {
+				currentCategory.Index = idx
+				idx++
+				lastBlock := result[len(result)-1].Blocks[len(result[len(result)-1].Blocks)-1]
+				lastColumn := lastBlock.Columns[len(lastBlock.Columns)-1]
+				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
+				currentCategory = nil
+			}
+			currentTab = strings.TrimSpace(line[4:])
+			result = append(result, &BookmarkPage{Tab: currentTab, Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}})
+			continue
+		}
 		if strings.EqualFold(line, "Page") {
 			if currentCategory != nil {
 				currentCategory.Index = idx
@@ -45,7 +60,7 @@ func PreprocessBookmarks(bookmarks string) []*BookmarkPage {
 				lastColumn.Categories = append(lastColumn.Categories, currentCategory)
 				currentCategory = nil
 			}
-			result = append(result, &BookmarkPage{Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}})
+			result = append(result, &BookmarkPage{Tab: currentTab, Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}})
 			continue
 		}
 		if line == "--" {

--- a/bookmarkTabEdit.go
+++ b/bookmarkTabEdit.go
@@ -1,0 +1,85 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExtractTab returns the text for a tab by name including the 'Tab:' line.
+func ExtractTab(bookmarks, name string) (string, error) {
+	lines := strings.Split(bookmarks, "\n")
+	start := -1
+	end := len(lines)
+	lower := strings.ToLower(name)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), "tab:") {
+			tabName := strings.TrimSpace(line[4:])
+			if start == -1 && strings.EqualFold(tabName, lower) {
+				start = i
+			} else if start != -1 {
+				end = i
+				break
+			}
+		}
+	}
+	if start == -1 {
+		return "", fmt.Errorf("tab %s not found", name)
+	}
+	return strings.Join(lines[start:end], "\n"), nil
+}
+
+// ReplaceTab replaces the tab with name with newName and newText.
+// newText should not include the leading 'Tab:' line.
+func ReplaceTab(bookmarks, name, newName, newText string) (string, error) {
+	lines := strings.Split(bookmarks, "\n")
+	start := -1
+	end := len(lines)
+	lower := strings.ToLower(name)
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), "tab:") {
+			tabName := strings.TrimSpace(line[4:])
+			if start == -1 && strings.EqualFold(tabName, lower) {
+				start = i
+			} else if start != -1 {
+				end = i
+				break
+			}
+		}
+	}
+	if start == -1 {
+		return "", fmt.Errorf("tab %s not found", name)
+	}
+	var result []string
+	result = append(result, lines[:start]...)
+	result = append(result, "Tab: "+newName)
+	if newText != "" {
+		newLines := strings.Split(strings.TrimSuffix(newText, "\n"), "\n")
+		result = append(result, newLines...)
+	}
+	result = append(result, lines[end:]...)
+	return strings.Join(result, "\n"), nil
+}
+
+// AppendTab appends a new tab with name and text to bookmarks.
+func AppendTab(bookmarks, name, text string) string {
+	if !strings.HasSuffix(bookmarks, "\n") {
+		bookmarks += "\n"
+	}
+	bookmarks += "Tab: " + name
+	if text != "" {
+		if !strings.HasSuffix(text, "\n") {
+			text += "\n"
+		}
+		bookmarks += "\n" + strings.TrimSuffix(text, "\n")
+	}
+	if !strings.HasSuffix(bookmarks, "\n") {
+		bookmarks += "\n"
+	} else {
+		if !strings.HasSuffix(bookmarks, "\n\n") {
+			bookmarks += ""
+		}
+	}
+	return bookmarks
+}

--- a/bookmarkTabEdit_test.go
+++ b/bookmarkTabEdit_test.go
@@ -1,0 +1,46 @@
+package gobookmarks
+
+import "testing"
+
+const tabBookmarkText = `Tab: One
+Category: A
+--
+Tab: Two
+Category: B
+`
+
+func TestExtractTab(t *testing.T) {
+	got, err := ExtractTab(tabBookmarkText, "Two")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	expected := "Tab: Two\nCategory: B\n"
+	if got != expected {
+		t.Fatalf("expected %q got %q", expected, got)
+	}
+}
+
+func TestExtractTabError(t *testing.T) {
+	if _, err := ExtractTab(tabBookmarkText, "X"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestReplaceTab(t *testing.T) {
+	updated, err := ReplaceTab(tabBookmarkText, "Two", "Z", "Category: C")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	expected := "Tab: One\nCategory: A\n--\nTab: Z\nCategory: C"
+	if updated != expected {
+		t.Fatalf("expected %q got %q", expected, updated)
+	}
+}
+
+func TestAppendTab(t *testing.T) {
+	updated := AppendTab("Category: X", "New", "Category: Y")
+	expected := "Category: X\nTab: New\nCategory: Y\n"
+	if updated != expected {
+		t.Fatalf("expected %q got %q", expected, updated)
+	}
+}

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -189,6 +189,11 @@ func main() {
 	r.HandleFunc("/editCategory", runHandlerChain(CategoryEditSaveAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save"))
 	r.HandleFunc("/editCategory", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
+	r.HandleFunc("/editTab", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
+	r.HandleFunc("/editTab", runHandlerChain(EditTabPage)).Methods("GET").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/editTab", runHandlerChain(TabEditSaveAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save"))
+	r.HandleFunc("/editTab", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
+
 	r.HandleFunc("/history", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/history", runTemplate("history.gohtml")).Methods("GET").MatcherFunc(RequiresAnAccount())
 

--- a/data_test.go
+++ b/data_test.go
@@ -17,6 +17,7 @@ func TestCompileGoHTML(t *testing.T) {
 	files := []string{
 		"edit.gohtml",
 		"editCategory.gohtml",
+		"editTab.gohtml",
 		"editNotes.gohtml",
 		"error.gohtml",
 		"head.gohtml",
@@ -42,6 +43,9 @@ func testFuncMap() template.FuncMap {
 		"version":       func() string { return "test" },
 		"OAuth2URL":     func() string { return "https://example.com" },
 		"ref":           func() string { return "refs/heads/main" },
+		"add1":          func(i int) int { return i + 1 },
+		"tab":           func() string { return "" },
+		"bookmarkTabs":  func() ([]string, error) { return []string{"tab"}, nil },
 		"useCssColumns": func() bool { return false },
 		"loggedIn":      func() (bool, error) { return true, nil },
 		"commitShort": func() string {

--- a/tabEditHandlers.go
+++ b/tabEditHandlers.go
@@ -1,0 +1,101 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"github.com/gorilla/sessions"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strings"
+)
+
+func EditTabPage(w http.ResponseWriter, r *http.Request) error {
+	tabName := r.URL.Query().Get("name")
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	ref := r.URL.Query().Get("ref")
+
+	login := ""
+	if githubUser != nil {
+		login = githubUser.Login
+	}
+
+	bookmarks, sha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	text := ""
+	if tabName != "" {
+		t, err := ExtractTab(bookmarks, tabName)
+		if err != nil {
+			return fmt.Errorf("ExtractTab: %w", err)
+		}
+		// drop first line (Tab: ...)
+		lines := strings.SplitN(t, "\n", 2)
+		if len(lines) == 2 {
+			text = lines[1]
+		}
+	}
+
+	data := struct {
+		*CoreData
+		Error   string
+		Name    string
+		OldName string
+		Text    string
+		Sha     string
+	}{
+		CoreData: r.Context().Value(ContextValues("coreData")).(*CoreData),
+		Error:    r.URL.Query().Get("error"),
+		Name:     tabName,
+		OldName:  tabName,
+		Text:     text,
+		Sha:      sha,
+	}
+
+	if err := GetCompiledTemplates(NewFuncs(r)).ExecuteTemplate(w, "editTab.gohtml", data); err != nil {
+		return fmt.Errorf("template: %w", err)
+	}
+	return nil
+}
+
+func TabEditSaveAction(w http.ResponseWriter, r *http.Request) error {
+	oldName := r.URL.Query().Get("name")
+	name := r.PostFormValue("name")
+	text := r.PostFormValue("text")
+	branch := r.PostFormValue("branch")
+	ref := r.PostFormValue("ref")
+	sha := r.PostFormValue("sha")
+
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+
+	login := ""
+	if githubUser != nil {
+		login = githubUser.Login
+	}
+
+	currentBookmarks, curSha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	if sha != "" && curSha != sha {
+		return fmt.Errorf("bookmark modified concurrently")
+	}
+
+	var updated string
+	if oldName == "" {
+		updated = AppendTab(currentBookmarks, name, text)
+	} else {
+		updated, err = ReplaceTab(currentBookmarks, oldName, name, text)
+		if err != nil {
+			return fmt.Errorf("ReplaceTab: %w", err)
+		}
+	}
+
+	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, updated, curSha); err != nil {
+		return fmt.Errorf("updateBookmark error: %w", err)
+	}
+	return nil
+}

--- a/templates/editTab.gohtml
+++ b/templates/editTab.gohtml
@@ -1,0 +1,15 @@
+{{ template "head" $ }}
+    {{ if $.Error }}
+        <p style="color: #FF0000">Error: {{ $.Error }}</p>
+    {{ end }}
+    <form method=post action="?name={{$.OldName}}" class="edit-form tab-form">
+        <label for="name">Name</label>: <input id="name" type="text" name="name" value="{{$.Name}}" /><br>
+        <label for="code">Tab Contents</label><br/>
+        <textarea id="code" name="text" rows="10">{{$.Text}}</textarea><br>
+        <label for="branch">Branch</label>: <input id="branch" type="text" name="branch" value="{{ branchOrEditBranch }}" /><br>
+        <input type=submit name="task" value="Save" /><br>
+        <input type=hidden name="ref" value="{{ref}}" />
+        <input type=hidden name="sha" value="{{bookmarksSHA}}" />
+    </form>
+    {{ template "editNotes" $ }}
+{{ template "tail" $ }}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -18,12 +18,22 @@
 			<tr valign=top>
 				<td width=200px>
 					<a href="/">Home</a><br>
-					{{ if $.UserRef }}
-						<a href="/logout">Logout</a><br/>
-						<a href="/history">History</a><br/>
-						{{if ref}}<a href="/edit?ref={{ref}}">Edit</a>{{else}}<a href="/edit">Edit</a>{{end}}<br/>
-					{{ else }}
-						<a href="{{ OAuth2URL }}">Login</a><br>
-					{{ end }}
-				<td>
+                                        {{ if $.UserRef }}
+                                                <a href="/logout">Logout</a><br/>
+                                                <a href="/history">History</a><br/>
+                                                {{if ref}}<a href="/edit?ref={{ref}}">Edit</a>{{else}}<a href="/edit">Edit</a>{{end}}<br/>
+                                        {{ else }}
+                                                <a href="{{ OAuth2URL }}">Login</a><br>
+                                        {{ end }}
+                                        <hr/>
+                                        <b>Tabs</b><br/>
+                                        {{- range bookmarkTabs }}
+                                                <a href="/?tab={{ . }}">{{ . }}</a><br/>
+                                        {{- end }}
+                                        <hr/>
+                                        <b>Pages</b><br/>
+                                        {{- range $i, $p := bookmarkPages }}
+                                                <a href="#page{{$i}}">Page {{ add1 $i }}</a><br/>
+                                        {{- end }}
+                                <td>
 {{end}}

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -6,8 +6,9 @@
         {{- if not bookmarksExist }}
         <p>Your bookmarks repository was not found. Click <a href="/edit">here</a> to create it.</p>
         {{- end }}
-        {{- range bookmarkPages }}
-        <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}">
+        {{- if tab }}<h1>{{ tab }} <a class="edit-link" href="/editTab?name={{ tab }}&ref={{ref}}" title="Edit">&#9998;</a></h1>{{ end }}
+        {{- range $i, $p := bookmarkPages }}
+        <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{$i}}">
             {{- range .Blocks }}
             {{- if .HR }}
             <hr class="bookmarkHr" />
@@ -56,5 +57,6 @@
             {{- end }}
         </div>
         {{- end }}
+        <p><a href="/editTab?ref={{ref}}">Add Tab</a></p>
     {{end}}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add tab editing handlers and template
- support adding new tabs via index footer
- expose tab edit link on page header
- helper functions for extracting and updating tabs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68453aa7bd2c832f98a5fa2705762a78