### PR TITLE
Add test for login route with gorilla/mux

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/gorilla/mux"
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"log"
@@ -39,7 +40,7 @@ var (
 )
 
 func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
-	providerName := r.PathValue("provider")
+	providerName := mux.Vars(r)["provider"]
 	p := GetProvider(providerName)
 	if p == nil {
 		http.NotFound(w, r)

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -1,0 +1,43 @@
+package gobookmarks
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoginRouteProviderVariable(t *testing.T) {
+	SessionName = "testsess"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+	version = "vtest"
+	GithubClientID = "id"
+	GithubClientSecret = "secret"
+	GitlabClientID = "id"
+	GitlabClientSecret = "secret"
+	OauthRedirectURL = "http://example.com/callback"
+
+	r := mux.NewRouter()
+	r.HandleFunc("/login/{provider}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
+
+	req := httptest.NewRequest("GET", "/login/github", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	res := w.Result()
+	if res.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("expected redirect, got %d", res.StatusCode)
+	}
+	loc := res.Header.Get("Location")
+	if !strings.Contains(loc, "github") {
+		t.Fatalf("redirect location does not contain provider: %s", loc)
+	}
+
+	req = httptest.NewRequest("GET", "/login/unknown", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown provider, got %d", w.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test verifying `/login/{provider}` works
- fix `LoginWithProvider` to use `mux.Vars` so gorilla/mux sets path values

## Testing
- `/root/go/bin/go1.24.4 test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68469fe43670832fbd437ab340721c3c