### PR TITLE
Add unified login page

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -253,6 +253,7 @@ func main() {
 	r.HandleFunc("/status", runTemplate("statusPage.gohtml")).Methods("GET")
 	r.HandleFunc("/history/commits", runTemplate("historyCommits.gohtml")).Methods("GET").MatcherFunc(RequiresAnAccount())
 
+	r.HandleFunc("/login", runTemplate("loginPage.gohtml")).Methods("GET")
 	r.HandleFunc("/login/json", runTemplate("jsonLoginPage.gohtml")).Methods("GET")
 	r.HandleFunc("/login/json", runHandlerChain(JSONLoginAction, redirectToHandler("/"))).Methods("POST")
 	r.HandleFunc("/login/{provider}", runHandlerChain(LoginWithProvider)).Methods("GET")

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -34,11 +34,7 @@
                                                         <a href="#page{{$i}}">Page {{ add1 $i }}</a><br/>
                                                 {{- end }}
                                         {{ else }}
-                                                {{- if Providers }}
-                                                {{- range Providers }}
-                                                <a href="{{ LoginURL . }}">Login with {{ . }}</a><br>
-                                                {{- end }}
-                                                {{- end }}
+                                                <a href="/login">Login</a><br/>
                                         {{ end }}
                                <td>
 {{end}}

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -1,11 +1,6 @@
 {{ template "head" $ }}
     {{ if not loggedIn }}
-        You will need to login to see this page:<br>
-        {{- if Providers }}
-        {{- range Providers }}
-        <a href="{{ LoginURL . }}">Login with {{ . }}</a><br>
-        {{- end }}
-        {{- end }}
+        You will need to login to see this page: <a href="/login">Login</a><br>
     {{else}}
         {{- if not bookmarksExist }}
         <p>Your bookmarks repository was not found. Click <a href="/edit">here</a> to create it.</p>


### PR DESCRIPTION
## Summary
- link to a single `/login` page when not authenticated
- add `/login` route that shows all providers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846d9eb7000832f9d05b44494b748ab