### PR TITLE
Remove extra signup page

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -256,6 +256,7 @@ func main() {
 	r.HandleFunc("/login", runTemplate("loginPage.gohtml")).Methods("GET")
 	r.HandleFunc("/login/json", runTemplate("jsonLoginPage.gohtml")).Methods("GET")
 	r.HandleFunc("/login/json", runHandlerChain(JSONLoginAction, redirectToHandler("/"))).Methods("POST")
+	r.HandleFunc("/signup/json", runHandlerChain(JSONSignupAction, redirectToHandler("/login/json"))).Methods("POST")
 	r.HandleFunc("/login/{provider}", runHandlerChain(LoginWithProvider)).Methods("GET")
 	r.HandleFunc("/logout", runHandlerChain(UserLogoutAction, runTemplate("logoutPage.gohtml"))).Methods("GET")
 	r.HandleFunc("/oauth2Callback", runHandlerChain(Oauth2CallbackPage, redirectToHandler("/"))).Methods("GET")

--- a/templates/jsonLoginPage.gohtml
+++ b/templates/jsonLoginPage.gohtml
@@ -4,5 +4,6 @@
     Username: <input type="text" name="username"><br>
     Password: <input type="password" name="password"><br>
     <input type="submit" value="Login">
+    <input type="submit" formaction="/signup/json" value="Sign Up">
 </form>
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- remove dedicated JSON signup page and use login page instead
- add signup button inside login form
- update signup action redirect when a user exists
- drop /signup/json GET route

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846dd6ff960832fa13bd3d17a846abf