### PR TITLE
Refine repo creation during signup

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -193,8 +193,13 @@ func GitSignupAction(w http.ResponseWriter, r *http.Request) error {
 		log.Printf("git signup create user error for %s: %v", user, err)
 		return err
 	}
-	if err := prov.CreateRepo(r.Context(), user, nil, RepoName); err != nil {
-		log.Printf("git signup create repo error for %s: %v", user, err)
+	if exists, err := prov.RepoExists(r.Context(), user, nil, RepoName); err == nil && !exists {
+		if err := prov.CreateRepo(r.Context(), user, nil, RepoName); err != nil {
+			log.Printf("git signup create repo error for %s: %v", user, err)
+			return err
+		}
+	} else if err != nil {
+		log.Printf("git signup repo check error for %s: %v", user, err)
 		return err
 	}
 	if err := prov.CreateBookmarks(r.Context(), user, nil, "main", defaultBookmarks); err != nil {

--- a/bookmarkActionHandlers.go
+++ b/bookmarkActionHandlers.go
@@ -26,6 +26,9 @@ func BookmarksEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 
 	_, curSha, err := GetBookmarks(r.Context(), login, ref, token)
 	if err != nil {
+		if errors.Is(err, ErrSignedOut) {
+			return ErrSignedOut
+		}
 		if errors.Is(err, ErrRepoNotFound) {
 			if p := providerFromContext(r.Context()); p != nil {
 				if err := p.CreateRepo(r.Context(), login, token, repoName); err == nil {

--- a/provider.go
+++ b/provider.go
@@ -37,6 +37,7 @@ type Provider interface {
 	UpdateBookmarks(ctx context.Context, user string, token *oauth2.Token, sourceRef, branch, text, expectSHA string) error
 	CreateBookmarks(ctx context.Context, user string, token *oauth2.Token, branch, text string) error
 	CreateRepo(ctx context.Context, user string, token *oauth2.Token, name string) error
+	RepoExists(ctx context.Context, user string, token *oauth2.Token, name string) (bool, error)
 	DefaultServer() string
 }
 

--- a/provider_github.go
+++ b/provider_github.go
@@ -187,6 +187,21 @@ See . https://github.com/arran4/gobookmarks `),
 	return nil
 }
 
+func (p GitHubProvider) RepoExists(ctx context.Context, user string, token *oauth2.Token, name string) (bool, error) {
+	client := p.client(ctx, token)
+	_, resp, err := client.Repositories.Get(ctx, user, name)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+			return false, ErrSignedOut
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func (p GitHubProvider) createRef(ctx context.Context, user string, client *github.Client, sourceRef, branchRef string) error {
 	gsref, resp, err := client.Git.GetRef(ctx, user, RepoName, sourceRef)
 	if resp != nil && resp.StatusCode == 404 {

--- a/provider_gitlab.go
+++ b/provider_gitlab.go
@@ -312,3 +312,21 @@ func (p GitLabProvider) CreateRepo(ctx context.Context, user string, token *oaut
 	}
 	return err
 }
+
+func (p GitLabProvider) RepoExists(ctx context.Context, user string, token *oauth2.Token, name string) (bool, error) {
+	c, err := GitLabProvider{}.client(token)
+	if err != nil {
+		return false, err
+	}
+	_, resp, err := c.Projects.GetProject(user+"/"+name, nil)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		if gitlabUnauthorized(err) {
+			return false, ErrSignedOut
+		}
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
## Summary
- add `RepoExists` to provider interface
- implement repo existence checks for Git, GitHub and GitLab
- update local signup flow to create the repo only when missing
- test repo existence for the local provider

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c284ac550832fa7b2a841af172bd5