### PR TITLE
Fix repo creation with dev namespace and oauth provider tracking

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -83,7 +83,7 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 		http.NotFound(w, r)
 		return nil
 	}
-	http.Redirect(w, r, cfg.AuthCodeURL(""), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, cfg.AuthCodeURL(providerName), http.StatusTemporaryRedirect)
 	return nil
 }
 
@@ -99,7 +99,10 @@ func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("session error: %w", err)
 	}
 
-	providerName, _ := session.Values["Provider"].(string)
+	providerName := r.URL.Query().Get("state")
+	if providerName == "" {
+		providerName, _ = session.Values["Provider"].(string)
+	}
 	p := GetProvider(providerName)
 	if p == nil {
 		return fmt.Errorf("unknown provider")

--- a/provider_github.go
+++ b/provider_github.go
@@ -282,13 +282,16 @@ func (p GitHubProvider) CreateBookmarks(ctx context.Context, user string, token 
 			return err
 		}
 	}
-	_, _, err := client.Repositories.CreateFile(ctx, user, RepoName, "bookmarks.txt", &github.RepositoryContentFileOptions{
+	_, resp, err := client.Repositories.CreateFile(ctx, user, RepoName, "bookmarks.txt", &github.RepositoryContentFileOptions{
 		Message:   SP("Auto create from web"),
 		Content:   []byte(text),
 		Branch:    &branch,
 		Author:    commitAuthor,
 		Committer: commitAuthor,
 	})
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return ErrRepoNotFound
+	}
 	if err != nil {
 		log.Printf("github CreateBookmarks: %v", err)
 		return fmt.Errorf("CreateBookmarks: %w", err)

--- a/repo.go
+++ b/repo.go
@@ -1,17 +1,23 @@
 package gobookmarks
 
+import "strings"
+
 var RepoName = GetBookmarksRepoName()
 
 // GetBookmarksRepoName returns the repository name based on the current
 // configuration and build mode. When running a development build the name is
 // suffixed with "-dev". The Namespace value is appended if supplied.
 func GetBookmarksRepoName() string {
-	name := "MyBookmarks"
-	if version == "dev" {
-		name += "-dev"
+	ns := Namespace
+	if strings.EqualFold(version, "dev") {
+		if ns == "" {
+			ns = version
+		}
 	}
-	if Namespace != "" {
-		name += "-" + Namespace
+
+	name := "MyBookmarks"
+	if ns != "" {
+		name += "-" + ns
 	}
 	return name
 }


### PR DESCRIPTION
## Summary
- determine namespace in GetBookmarksRepoName more accurately
- handle repo not found when creating bookmarks on GitHub
- track OAuth provider in `state` parameter to avoid unknown provider errors

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e5ea3e094832f83ead1da86088dbb