### PR TITLE
Improve config file loading logs

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -119,10 +119,20 @@ func main() {
 	if cfgFlag.set {
 		configPath = cfgFlag.value
 	}
-	if fileCfg, err := LoadConfigFile(configPath); err == nil {
-		MergeConfig(&cfg, fileCfg)
+
+	cfgSpecified := cfgFlag.set || os.Getenv("GOBM_CONFIG_FILE") != ""
+
+	if fileCfg, found, err := LoadConfigFile(configPath); err == nil {
+		if found {
+			MergeConfig(&cfg, fileCfg)
+		}
 	} else {
-		log.Printf("unable to load config file %s: %v", configPath, err)
+		if os.IsNotExist(err) && !cfgSpecified {
+			log.Printf("config file %s not found", configPath)
+		} else {
+			log.Printf("unable to load config file %s: %v", configPath, err)
+			os.Exit(1)
+		}
 	}
 
 	if ghIDFlag.set {


### PR DESCRIPTION
## Summary
- log attempts and successes when loading config files
- exit cleanly for config errors without stack traces

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ea467096c832fa859494a375c75bd