### PR TITLE
Improve Docker documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian
-VOLUME /data
+VOLUME /var/cache/gobookmarks
 VOLUME /etc/gobookmarks
-VOLUME /db
+VOLUME /var/lib/gobookmarks
 ENV EXTERNAL_URL=http://localhost:8080
 ENV GITHUB_CLIENT_ID=""
 ENV GITHUB_SECRET=""
@@ -9,9 +9,12 @@ ENV GITLAB_CLIENT_ID=""
 ENV GITLAB_SECRET=""
 ENV GBM_CSS_COLUMNS=""
 ENV GBM_NAMESPACE=""
-ENV FAVICON_CACHE_DIR=/data/favicons
+ENV GBM_TITLE=""
+ENV FAVICON_CACHE_DIR=/var/cache/gobookmarks/favcache
 ENV FAVICON_CACHE_SIZE=20971520
-ENV LOCAL_GIT_PATH=/db/gobookmarks
+ENV GITHUB_SERVER=""
+ENV GITLAB_SERVER=""
+ENV LOCAL_GIT_PATH=/var/lib/gobookmarks/localgit
 ENV GOBM_ENV_FILE=/etc/gobookmarks/gobookmarks.env
 ENV GOBM_CONFIG_FILE=/etc/gobookmarks/config.json
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- make environment variables explicit in Dockerfile
- expand README with docker run examples and docker compose samples
- document new default paths for cache and git data
- clarify that defaults apply when installed system-wide

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e7c7ef5e8832f94246604a938b4ba