### PR TITLE
Fix session decoding for old provider sessions

### DIFF
--- a/provider_github.go
+++ b/provider_github.go
@@ -5,6 +5,7 @@ package gobookmarks
 import (
 	"context"
 	"encoding/base64"
+	"encoding/gob"
 	"fmt"
 	"log"
 	"net/http"
@@ -17,7 +18,10 @@ import (
 // GitHubProvider implements Provider for GitHub.
 type GitHubProvider struct{}
 
-func init() { RegisterProvider(GitHubProvider{}) }
+func init() {
+	gob.Register(&github.User{})
+	RegisterProvider(GitHubProvider{})
+}
 
 func (GitHubProvider) Name() string { return "github" }
 

--- a/provider_gitlab.go
+++ b/provider_gitlab.go
@@ -5,6 +5,7 @@ package gobookmarks
 import (
 	"context"
 	"encoding/base64"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"log"
@@ -26,7 +27,10 @@ func gitlabUnauthorized(err error) bool {
 	return errors.As(err, &respErr) && respErr.Response != nil && respErr.Response.StatusCode == http.StatusUnauthorized
 }
 
-func init() { RegisterProvider(GitLabProvider{}) }
+func init() {
+	gob.Register(&gitlab.User{})
+	RegisterProvider(GitLabProvider{})
+}
 
 func (GitLabProvider) Name() string { return "gitlab" }
 


### PR DESCRIPTION
## Summary
- register GitHub and GitLab user types with gob within provider init functions
- remove previous github gob registration file

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ea5039ba4832f87eea30bc2b7a05f