### PR TITLE
Fix redirect URL construction

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -208,8 +208,8 @@ func main() {
 	githubSecret := cfg.GithubSecret
 	gitlabID := cfg.GitlabClientID
 	gitlabSecret := cfg.GitlabSecret
-	externalUrl = cfg.ExternalURL
-	redirectUrl = fmt.Sprintf("%s/oauth2Callback", externalUrl)
+	externalUrl = strings.TrimRight(cfg.ExternalURL, "/")
+	redirectUrl = JoinURL(externalUrl, "oauth2Callback")
 	GithubClientID = githubID
 	GithubClientSecret = githubSecret
 	GitlabClientID = gitlabID

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -17,7 +17,7 @@ func TestLoginRouteProviderVariable(t *testing.T) {
 	GithubClientSecret = "secret"
 	GitlabClientID = "id"
 	GitlabClientSecret = "secret"
-	OauthRedirectURL = "http://example.com/callback"
+	OauthRedirectURL = JoinURL("http://example.com/", "callback")
 
 	r := mux.NewRouter()
 	r.HandleFunc("/login/{provider}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")

--- a/urlutils.go
+++ b/urlutils.go
@@ -1,0 +1,14 @@
+package gobookmarks
+
+import "strings"
+
+// JoinURL joins base and elem ensuring there is exactly one slash between them.
+// Additional leading or trailing slashes are removed from elem.
+func JoinURL(base, elem string) string {
+	base = strings.TrimRight(base, "/")
+	elem = strings.TrimLeft(elem, "/")
+	if base == "" {
+		return "/" + elem
+	}
+	return base + "/" + elem
+}

--- a/urlutils_test.go
+++ b/urlutils_test.go
@@ -1,0 +1,22 @@
+package gobookmarks
+
+import "testing"
+
+func TestJoinURL(t *testing.T) {
+	tests := []struct {
+		base string
+		elem string
+		want string
+	}{
+		{"http://example.com", "oauth2Callback", "http://example.com/oauth2Callback"},
+		{"http://example.com/", "oauth2Callback", "http://example.com/oauth2Callback"},
+		{"http://example.com///", "oauth2Callback", "http://example.com/oauth2Callback"},
+		{"http://example.com/base", "oauth2Callback", "http://example.com/base/oauth2Callback"},
+	}
+	for _, tt := range tests {
+		got := JoinURL(tt.base, tt.elem)
+		if got != tt.want {
+			t.Fatalf("JoinURL(%q, %q) = %q, want %q", tt.base, tt.elem, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- sanitize joining of ExternalURL and callback path
- add JoinURL helper
- use JoinURL in login tests and add dedicated tests for JoinURL

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684ebce60240832fbf3dbffbd6ad898a