### PR TITLE
Improve startup check for providers

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -222,6 +222,10 @@ func main() {
 		fmt.Println("no providers compiled")
 		os.Exit(-1)
 	}
+	if len(ConfiguredProviderNames()) == 0 {
+		fmt.Println("no providers available")
+		os.Exit(-1)
+	}
 
 	r := mux.NewRouter()
 

--- a/provider.go
+++ b/provider.go
@@ -67,3 +67,16 @@ func ProviderNames() []string {
 	}
 	return names
 }
+
+// ConfiguredProviderNames returns the list of providers that are both
+// compiled in and configured for use. A provider is considered configured
+// when providerCreds returns non-nil.
+func ConfiguredProviderNames() []string {
+	names := make([]string, 0, len(providers))
+	for _, n := range ProviderNames() {
+		if providerCreds(n) != nil {
+			names = append(names, n)
+		}
+	}
+	return names
+}


### PR DESCRIPTION
## Summary
- add `ConfiguredProviderNames` helper to check for usable providers
- exit with a message when no providers are configured

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684feaf78434832fa93eacbace7b6341