### PR TITLE
Add footer toggle option

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -72,6 +72,7 @@ func main() {
 			return 0
 		}(),
 		LocalGitPath: os.Getenv("LOCAL_GIT_PATH"),
+		NoFooter:     os.Getenv("GBM_NO_FOOTER") != "",
 	}
 
 	configPath := DefaultConfigPath()
@@ -90,6 +91,7 @@ func main() {
 	var faviconSizeFlag stringFlag
 	var localGitPathFlag stringFlag
 	var columnFlag boolFlag
+	var noFooterFlag boolFlag
 	var versionFlag bool
 	var dumpConfig bool
 	flag.Var(&cfgFlag, "config", "path to config file")
@@ -106,6 +108,7 @@ func main() {
 	flag.Var(&glServerFlag, "gitlab-server", "GitLab base URL")
 	flag.Var(&localGitPathFlag, "local-git-path", "directory for local git provider")
 	flag.Var(&columnFlag, "css-columns", "use CSS columns")
+	flag.Var(&noFooterFlag, "no-footer", "disable footer on pages")
 	flag.BoolVar(&versionFlag, "version", false, "show version")
 	flag.BoolVar(&dumpConfig, "dump-config", false, "print merged config and exit")
 	flag.Parse()
@@ -159,6 +162,9 @@ func main() {
 	if columnFlag.set {
 		cfg.CssColumns = columnFlag.value
 	}
+	if noFooterFlag.set {
+		cfg.NoFooter = noFooterFlag.value
+	}
 	if ghServerFlag.set {
 		cfg.GithubServer = ghServerFlag.value
 	}
@@ -187,6 +193,7 @@ func main() {
 	Namespace = cfg.Namespace
 	RepoName = GetBookmarksRepoName()
 	SiteTitle = cfg.Title
+	NoFooter = cfg.NoFooter
 	if cfg.GithubServer != "" {
 		GithubServer = cfg.GithubServer
 	}

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	FaviconCacheDir  string `json:"favicon_cache_dir"`
 	FaviconCacheSize int64  `json:"favicon_cache_size"`
 	LocalGitPath     string `json:"local_git_path"`
+	NoFooter         bool   `json:"no_footer"`
 }
 
 // LoadConfigFile loads configuration from the given path.
@@ -111,6 +112,9 @@ func MergeConfig(dst *Config, src Config) {
 	}
 	if src.LocalGitPath != "" {
 		dst.LocalGitPath = src.LocalGitPath
+	}
+	if src.NoFooter {
+		dst.NoFooter = true
 	}
 }
 

--- a/data_test.go
+++ b/data_test.go
@@ -52,6 +52,7 @@ func testFuncMap() template.FuncMap {
 		"tab":                func() string { return "" },
 		"bookmarkTabs":       func() ([]string, error) { return []string{"tab"}, nil },
 		"useCssColumns":      func() bool { return false },
+		"showFooter":         func() bool { return true },
 		"loggedIn":           func() (bool, error) { return true, nil },
 		"commitShort": func() string {
 			short := commit

--- a/funcs.go
+++ b/funcs.go
@@ -83,6 +83,9 @@ func NewFuncs(r *http.Request) template.FuncMap {
 		"useCssColumns": func() bool {
 			return UseCssColumns
 		},
+		"showFooter": func() bool {
+			return !NoFooter
+		},
 		"loggedIn": func() (bool, error) {
 			session := r.Context().Value(ContextValues("session")).(*sessions.Session)
 			githubUser, ok := session.Values["GithubUser"].(*User)

--- a/settings.go
+++ b/settings.go
@@ -6,6 +6,7 @@ var (
 	UseCssColumns bool
 	Namespace     string
 	SiteTitle     string
+	NoFooter      bool
 
 	GithubServer string
 	GitlabServer string

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -1,7 +1,8 @@
 {{define "tail"}}
                  </table>
                  <div id="bottom"></div>
-                 <hr>
+                {{ if showFooter }}
+                <hr>
                 <footer class="footnote">
                        <div>Date and time is now: {{ now.Format "2006-01-02 15:04:05 MST" }}</div>
                        <div>
@@ -14,6 +15,7 @@
                                </i>
                        </div>
                 </footer>
+                {{ end }}
                  </body>
 </html>
 {{end}}


### PR DESCRIPTION
## Summary
- allow disabling the footer via config/env/flag
- expose `showFooter` to templates
- update tests and templates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685009fdf8b4832fb88246b6ea5a2774