### PR TITLE
Add bookmark serializer and round-trip unit test

### DIFF
--- a/bookmarkSerialize.go
+++ b/bookmarkSerialize.go
@@ -1,0 +1,63 @@
+package gobookmarks
+
+import "strings"
+
+// SerializeBookmarks converts a tree of BookmarkTab back into the
+// textual bookmark representation understood by PreprocessBookmarks.
+func SerializeBookmarks(tabs []*BookmarkTab) string {
+	var b strings.Builder
+	for ti, t := range tabs {
+		// omit explicit Tab directive for the first unnamed tab
+		if !(ti == 0 && t.Name == "") {
+			if t.Name != "" {
+				b.WriteString("Tab: ")
+				b.WriteString(t.Name)
+				b.WriteString("\n")
+			} else {
+				b.WriteString("Tab\n")
+			}
+		}
+		for pj, p := range t.Pages {
+			if pj == 0 {
+				if p.Name != "" {
+					b.WriteString("Page: ")
+					b.WriteString(p.Name)
+					b.WriteString("\n")
+				}
+			} else {
+				if p.Name != "" {
+					b.WriteString("Page: ")
+					b.WriteString(p.Name)
+					b.WriteString("\n")
+				} else {
+					b.WriteString("Page\n")
+				}
+			}
+			for _, blk := range p.Blocks {
+				if blk.HR {
+					b.WriteString("--\n")
+					continue
+				}
+				for ci, col := range blk.Columns {
+					if ci > 0 {
+						b.WriteString("Column\n")
+					}
+					for _, cat := range col.Categories {
+						b.WriteString("Category: ")
+						b.WriteString(cat.Name)
+						b.WriteString("\n")
+						for _, ent := range cat.Entries {
+							b.WriteString(ent.Url)
+							if ent.Name != ent.Url {
+								b.WriteString(" ")
+								b.WriteString(ent.Name)
+							}
+							b.WriteString("\n")
+						}
+					}
+				}
+			}
+		}
+	}
+	return b.String()
+}

--- a/bookmarkSerialize_test.go
+++ b/bookmarkSerialize_test.go
@@ -1,0 +1,22 @@
+package gobookmarks
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"testing"
+)
+
+func TestSerializeBookmarksRoundTrip(t *testing.T) {
+	samples := []string{
+		defaultBookmarks,
+		complexBookmarkText,
+		multiBookmarkText,
+	}
+	for _, in := range samples {
+		tabs1 := PreprocessBookmarks(in)
+		out := SerializeBookmarks(tabs1)
+		tabs2 := PreprocessBookmarks(out)
+		if diff := cmp.Diff(tabs1, tabs2); diff != "" {
+			t.Fatalf("round trip diff:\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement `SerializeBookmarks` to convert bookmark data back to text
- test that serializing then re-parsing yields the original structure

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685204ad3860832f91aee1af47e740e6