### PR TITLE
Add edit mode flag and handlers

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -257,6 +257,9 @@ func main() {
 	r.HandleFunc("/edit", runHandlerChain(BookmarksEditCreateAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Create"))
 	r.HandleFunc("/edit", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
+	r.HandleFunc("/startEditMode", runHandlerChain(StartEditMode, redirectToHandler("/"))).Methods("POST").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/stopEditMode", runHandlerChain(StopEditMode, redirectToHandler("/"))).Methods("POST").MatcherFunc(RequiresAnAccount())
+
 	r.HandleFunc("/editCategory", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/editCategory", runHandlerChain(EditCategoryPage)).Methods("GET").MatcherFunc(RequiresAnAccount())
 	r.HandleFunc("/editCategory", runHandlerChain(CategoryEditSaveAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save"))

--- a/core.go
+++ b/core.go
@@ -37,9 +37,11 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		}
 
 		ctx := context.WithValue(request.Context(), ContextValues("provider"), providerName)
+		editMode, _ := session.Values["editMode"].(bool)
 		ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{
-			UserRef: login,
-			Title:   title,
+			UserRef:  login,
+			Title:    title,
+			EditMode: editMode,
 		})
 		next.ServeHTTP(writer, request.WithContext(ctx))
 	})
@@ -49,6 +51,7 @@ type CoreData struct {
 	Title       string
 	AutoRefresh bool
 	UserRef     string
+	EditMode    bool
 }
 
 type Configuration struct {

--- a/editModeHandlers.go
+++ b/editModeHandlers.go
@@ -1,0 +1,27 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"github.com/gorilla/sessions"
+	"net/http"
+)
+
+// StartEditMode enables edit mode by storing a flag in the user's session.
+func StartEditMode(w http.ResponseWriter, r *http.Request) error {
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	session.Values["editMode"] = true
+	if err := session.Save(r, w); err != nil {
+		return fmt.Errorf("session save: %w", err)
+	}
+	return nil
+}
+
+// StopEditMode disables edit mode and clears the flag from the session.
+func StopEditMode(w http.ResponseWriter, r *http.Request) error {
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	delete(session.Values, "editMode")
+	if err := session.Save(r, w); err != nil {
+		return fmt.Errorf("session save: %w", err)
+	}
+	return nil
+}

--- a/editModeHandlers_test.go
+++ b/editModeHandlers_test.go
@@ -1,0 +1,59 @@
+package gobookmarks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+func TestEditModeToggle(t *testing.T) {
+	SessionName = "testsession"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	session, err := getSession(w, req)
+	if err != nil {
+		t.Fatalf("getSession: %v", err)
+	}
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	// enable edit mode
+	w = httptest.NewRecorder()
+	if err := StartEditMode(w, req); err != nil {
+		t.Fatalf("StartEditMode: %v", err)
+	}
+	if v, ok := session.Values["editMode"].(bool); !ok || !v {
+		t.Fatalf("edit mode not enabled in session")
+	}
+
+	var cd *CoreData
+	handler := CoreAdderMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cd = r.Context().Value(ContextValues("coreData")).(*CoreData)
+	}))
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if cd == nil || !cd.EditMode {
+		t.Fatalf("EditMode flag not propagated via middleware")
+	}
+
+	// disable edit mode
+	w = httptest.NewRecorder()
+	if err := StopEditMode(w, req); err != nil {
+		t.Fatalf("StopEditMode: %v", err)
+	}
+	if v, ok := session.Values["editMode"].(bool); ok && v {
+		t.Fatalf("edit mode flag should be cleared")
+	}
+
+	cd = nil
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if cd == nil || cd.EditMode {
+		t.Fatalf("EditMode flag should be false after disabling")
+	}
+}

--- a/main.css
+++ b/main.css
@@ -106,6 +106,10 @@ div.title {
         text-decoration: none;
 }
 
+body:not(.edit-mode) .edit-link {
+        display: none;
+}
+
 .edit-form textarea {
         width: 90vw;
         height: 80vh;

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -10,8 +10,8 @@
         {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}
-	</head>
-        <body>
+        </head>
+        <body{{if $.EditMode}} class="edit-mode"{{end}}>
                 <table border=0 id="layout">
                         <tr valign=top>
                                 <td width=200px id="nav">
@@ -20,7 +20,10 @@
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>
                                                 <a href="/history">History</a><br/>
-                                                {{if ref}}<a href="/edit?ref={{ref}}">Edit</a>{{else}}<a href="/edit">Edit</a>{{end}}<br/>
+                                                <form method="post" action="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}" style="display:inline">
+                                                        <button type="submit">{{if $.EditMode}}Stop Edit Mode{{else}}Edit Mode{{end}}</button>
+                                                </form><br/>
+                                                {{if ref}}<a href="/edit?ref={{ref}}">Edit All</a>{{else}}<a href="/edit">Edit All</a>{{end}}<br/>
                                                 <hr/>
                                                 <b>Tabs</b><br/>
                                                 <a href="/">Main</a><br/>


### PR DESCRIPTION
## Summary
- add EditMode to CoreData and pipe session state through CoreAdderMiddleware
- implement StartEditMode and StopEditMode handlers
- test that the edit mode flag toggles correctly
- add UI links for toggling edit mode and hide icons unless active

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685204e1cee8832fa4302211c3468f63