### PR TITLE
Remember tab and page after edits

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -497,6 +497,12 @@ func redirectToHandlerBranchToRef(toUrl string) func(http.ResponseWriter, *http.
 		u, _ := url.Parse(toUrl)
 		qs := u.Query()
 		qs.Set("ref", "refs/heads/"+r.PostFormValue("branch"))
+		if tab := r.PostFormValue("tab"); tab != "" {
+			qs.Set("tab", tab)
+		}
+		if page := r.PostFormValue("page"); page != "" {
+			u.Fragment = "page" + page
+		}
 		u.RawQuery = qs.Encode()
 		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
 	})

--- a/data_test.go
+++ b/data_test.go
@@ -50,6 +50,7 @@ func testFuncMap() template.FuncMap {
 		"ref":                func() string { return "refs/heads/main" },
 		"add1":               func(i int) int { return i + 1 },
 		"tab":                func() string { return "" },
+		"page":               func() string { return "" },
 		"bookmarkTabs":       func() ([]string, error) { return []string{"tab"}, nil },
 		"useCssColumns":      func() bool { return false },
 		"showFooter":         func() bool { return true },

--- a/funcs.go
+++ b/funcs.go
@@ -77,6 +77,9 @@ func NewFuncs(r *http.Request) template.FuncMap {
 		"tab": func() string {
 			return r.URL.Query().Get("tab")
 		},
+		"page": func() string {
+			return r.URL.Query().Get("page")
+		},
 		"add1": func(i int) int {
 			return i + 1
 		},

--- a/templates/edit.gohtml
+++ b/templates/edit.gohtml
@@ -11,6 +11,7 @@
         <input type=submit name="task" value="Save" /><br>
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
+        <input type=hidden name="tab" value="{{tab}}" />
     </form>
 
     {{ template "editNotes" $ }}

--- a/templates/editCategory.gohtml
+++ b/templates/editCategory.gohtml
@@ -9,6 +9,8 @@
         <input type=submit name="task" value="Save" /><br>
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
+        <input type=hidden name="tab" value="{{tab}}" />
+        <input type=hidden name="page" value="{{page}}" />
     </form>
     {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/editTab.gohtml
+++ b/templates/editTab.gohtml
@@ -10,6 +10,7 @@
         <input type=submit name="task" value="Save" /><br>
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
+        <input type=hidden name="tab" value="{{tab}}" />
     </form>
     {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -23,7 +23,7 @@
                                                 <form method="post" action="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}" style="display:inline">
                                                         <button type="submit">{{if $.EditMode}}Stop Edit Mode{{else}}Edit Mode{{end}}</button>
                                                 </form><br/>
-                                                {{if ref}}<a href="/edit?ref={{ref}}">Edit All</a>{{else}}<a href="/edit">Edit All</a>{{end}}<br/>
+                                                {{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>
                                                 <hr/>
                                                 <b>Tabs</b><br/>
                                                 <a href="/">Main</a><br/>

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -5,7 +5,7 @@
         {{- if not bookmarksExist }}
         <p>Your bookmarks repository was not found. Click <a href="/edit">here</a> to create it.</p>
         {{- end }}
-        {{- if tab }}<h1>{{ tab }} <a class="edit-link" href="/editTab?name={{ tab }}&ref={{ref}}" title="Edit">&#9998;</a></h1>{{ end }}
+        {{- if tab }}<h1>{{ tab }} <a class="edit-link" href="/editTab?name={{ tab }}&ref={{ref}}&tab={{tab}}" title="Edit">&#9998;</a></h1>{{ end }}
         {{- range $i, $p := bookmarkPages }}
         <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{$i}}">
             {{- if $p.Name }}<h2>{{ $p.Name }}</h2>{{ end }}
@@ -19,7 +19,7 @@
                     {{- if not $first }}<div class="columnBreak"></div>{{ end }}
                     {{- range .Categories }}
                         <div class="categoryBlock">
-                            <h2>{{ .Name }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}" title="Edit">&#9998;</a></h2>
+                            <h2>{{ .Name }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
                             <ul  style="list-style-type: none;">
                                 {{- range .Entries }}
                                     <li>
@@ -40,7 +40,7 @@
                     <td>
                         {{- range .Categories }}
                             <ul  style="list-style-type: none;">
-                                <h2>{{ .Name }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}" title="Edit">&#9998;</a></h2>
+                                <h2>{{ .Name }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
                                 {{- range .Entries }}
                                     <li>
                                         <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
@@ -57,6 +57,6 @@
             {{- end }}
         </div>
         {{- end }}
-        <p><a href="/editTab?ref={{ref}}">Add Tab</a></p>
+        <p><a href="/editTab?ref={{ref}}&tab={{tab}}">Add Tab</a></p>
     {{end}}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- preserve `tab` and page anchors when returning from edit actions
- include `page` query param function for templates
- expose tab/page to redirect logic and forms
- adjust tests for new template function

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685211023c34832f915afe2381862e3d