### PR TITLE
Use link for edit mode toggle

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -266,8 +266,8 @@ func main() {
 	r.HandleFunc("/edit", runHandlerChain(BookmarksEditCreateAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Create"))
 	r.HandleFunc("/edit", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
-	r.HandleFunc("/startEditMode", runHandlerChain(StartEditMode, redirectToHandler("/"))).Methods("POST").MatcherFunc(RequiresAnAccount())
-	r.HandleFunc("/stopEditMode", runHandlerChain(StopEditMode, redirectToHandler("/"))).Methods("POST").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/startEditMode", runHandlerChain(StartEditMode, redirectToHandler("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/stopEditMode", runHandlerChain(StopEditMode, redirectToHandler("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
 
 	r.HandleFunc("/editCategory", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/editCategory", runHandlerChain(EditCategoryPage)).Methods("GET").MatcherFunc(RequiresAnAccount())

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -20,10 +20,8 @@
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>
                                                 <a href="/history">History</a><br/>
-                                                <form method="post" action="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}" style="display:inline">
-                                                        <button type="submit">{{if $.EditMode}}Stop Edit Mode{{else}}Edit Mode{{end}}</button>
-                                                </form><br/>
-                                                {{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>
+                                                <a href="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
+                                                {{if $.EditMode}}{{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>{{end}}
                                                 <hr/>
                                                 <b>Tabs</b><br/>
                                                 <a href="/">Main</a><br/>


### PR DESCRIPTION
## Summary
- turn the "Edit" toggle into a link
- hide "Edit All" until edit mode is active
- allow GET methods for start/stop edit mode endpoints

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68524737c6fc832faee080f356938381