### PR TITLE
Enable drag and drop reordering

### DIFF
--- a/bookmark_methods_test.go
+++ b/bookmark_methods_test.go
@@ -151,6 +151,34 @@ func TestSwitchTab(t *testing.T) {
 	}
 }
 
+func TestMoveTab(t *testing.T) {
+	tabs := ParseBookmarks(switchTabInput)
+	var list BookmarkList = tabs
+	list.MoveTab(0, 1)
+	got := list.String()
+	if got != switchTabExpected {
+		t.Fatalf("expected %q got %q", switchTabExpected, got)
+	}
+}
+
+func TestMovePage(t *testing.T) {
+	tabs := ParseBookmarks(switchPageInput)
+	tabs[0].MovePage(0, 1)
+	got := tabs.String()
+	if got != switchPageExpected {
+		t.Fatalf("expected %q got %q", switchPageExpected, got)
+	}
+}
+
+func TestMoveEntry(t *testing.T) {
+	cat := &BookmarkCategory{Name: "C", Entries: []*BookmarkEntry{{Url: "u1"}, {Url: "u2"}}}
+	cat.MoveEntry(0, 1)
+	expected := "Category: C\nu2\nu1\n"
+	if got := cat.String(); got != expected {
+		t.Fatalf("expected %q got %q", expected, got)
+	}
+}
+
 func TestInvalidOperations(t *testing.T) {
 	tabs := ParseBookmarks(insertCategoryInput)
 	col := tabs[0].Pages[0].Blocks[0].Columns[0]

--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -75,6 +75,20 @@ func (c *BookmarkColumn) SwitchCategories(i, j int) {
 	c.Categories[i], c.Categories[j] = c.Categories[j], c.Categories[i]
 }
 
+// MoveEntry moves an entry within the category from index i to j.
+func (c *BookmarkCategory) MoveEntry(i, j int) {
+	if i < 0 || j < 0 || i >= len(c.Entries) || j >= len(c.Entries) || i == j {
+		return
+	}
+	entry := c.Entries[i]
+	if i < j {
+		copy(c.Entries[i:j], c.Entries[i+1:j+1])
+	} else {
+		copy(c.Entries[j+1:i+1], c.Entries[j:i])
+	}
+	c.Entries[j] = entry
+}
+
 // BookmarkBlock groups columns and optional horizontal rule.
 type BookmarkBlock struct {
 	Columns []*BookmarkColumn
@@ -132,6 +146,20 @@ func (t *BookmarkTab) SwitchPages(i, j int) {
 		return
 	}
 	t.Pages[i], t.Pages[j] = t.Pages[j], t.Pages[i]
+}
+
+// MovePage moves a page from index i to j within the tab.
+func (t *BookmarkTab) MovePage(i, j int) {
+	if i < 0 || j < 0 || i >= len(t.Pages) || j >= len(t.Pages) || i == j {
+		return
+	}
+	page := t.Pages[i]
+	if i < j {
+		copy(t.Pages[i:j], t.Pages[i+1:j+1])
+	} else {
+		copy(t.Pages[j+1:i+1], t.Pages[j:i])
+	}
+	t.Pages[j] = page
 }
 
 // BookmarkTab represents a tab of pages.
@@ -210,6 +238,20 @@ func (b BookmarkList) SwitchTabs(i, j int) {
 		return
 	}
 	b[i], b[j] = b[j], b[i]
+}
+
+// MoveTab moves a tab from index i to j in the list.
+func (b BookmarkList) MoveTab(i, j int) {
+	if i < 0 || j < 0 || i >= len(b) || j >= len(b) || i == j {
+		return
+	}
+	tab := b[i]
+	if i < j {
+		copy(b[i:j], b[i+1:j+1])
+	} else {
+		copy(b[j+1:i+1], b[j:i])
+	}
+	b[j] = tab
 }
 
 // ParseBookmarks converts the textual bookmark representation into a

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -279,6 +279,10 @@ func main() {
 	r.HandleFunc("/editTab", runHandlerChain(TabEditSaveAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Save"))
 	r.HandleFunc("/editTab", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
+	r.HandleFunc("/moveTab", runHandlerChain(MoveTabAction)).Methods("POST").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/movePage", runHandlerChain(MovePageAction)).Methods("POST").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/moveEntry", runHandlerChain(MoveEntryAction)).Methods("POST").MatcherFunc(RequiresAnAccount())
+
 	r.HandleFunc("/history", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/history", runTemplate("history.gohtml")).Methods("GET").MatcherFunc(RequiresAnAccount())
 

--- a/data_test.go
+++ b/data_test.go
@@ -25,8 +25,9 @@ func TestCompileGoHTML(t *testing.T) {
 		"historyCommits.gohtml",
 		"indexPage.gohtml",
 		"loginPage.gohtml",
-		"logoutPage.gohtml",
-		"tail.gohtml",
+               "logoutPage.gohtml",
+               "dragdrop.gohtml",
+               "tail.gohtml",
 		"taskDoneAutoRefreshPage.gohtml",
 		"statusPage.gohtml",
 	}

--- a/main.css
+++ b/main.css
@@ -156,3 +156,8 @@ body:not(.edit-mode) .edit-link {
 #bottom {
     flex-grow: 1;
 }
+
+.move-handle {
+    cursor: move;
+    margin-right: 0.3em;
+}

--- a/moveHandlers.go
+++ b/moveHandlers.go
@@ -1,0 +1,113 @@
+package gobookmarks
+
+import (
+	"fmt"
+	"github.com/gorilla/sessions"
+	"golang.org/x/oauth2"
+	"net/http"
+	"strconv"
+)
+
+func MoveTabAction(w http.ResponseWriter, r *http.Request) error {
+	from, _ := strconv.Atoi(r.URL.Query().Get("from"))
+	to, _ := strconv.Atoi(r.URL.Query().Get("to"))
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	login := ""
+	if githubUser != nil {
+		login = githubUser.Login
+	}
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		ref = "refs/heads/main"
+	}
+	bookmarks, sha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	list := ParseBookmarks(bookmarks)
+	list.MoveTab(from, to)
+	if err := UpdateBookmarks(r.Context(), login, token, ref, "main", list.String(), sha); err != nil {
+		return fmt.Errorf("updateBookmarks: %w", err)
+	}
+	return nil
+}
+
+func MovePageAction(w http.ResponseWriter, r *http.Request) error {
+	from, _ := strconv.Atoi(r.URL.Query().Get("from"))
+	to, _ := strconv.Atoi(r.URL.Query().Get("to"))
+	tabName := r.URL.Query().Get("tab")
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	login := ""
+	if githubUser != nil {
+		login = githubUser.Login
+	}
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		ref = "refs/heads/main"
+	}
+	bookmarks, sha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	list := ParseBookmarks(bookmarks)
+	for _, t := range list {
+		if t.DisplayName() == tabName || t.Name == tabName {
+			t.MovePage(from, to)
+			break
+		}
+	}
+	if err := UpdateBookmarks(r.Context(), login, token, ref, "main", list.String(), sha); err != nil {
+		return fmt.Errorf("updateBookmarks: %w", err)
+	}
+	return nil
+}
+
+func MoveEntryAction(w http.ResponseWriter, r *http.Request) error {
+	from, _ := strconv.Atoi(r.URL.Query().Get("from"))
+	to, _ := strconv.Atoi(r.URL.Query().Get("to"))
+	catIdx, _ := strconv.Atoi(r.URL.Query().Get("category"))
+	tabName := r.URL.Query().Get("tab")
+	pageIdx, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
+	githubUser, _ := session.Values["GithubUser"].(*User)
+	token, _ := session.Values["Token"].(*oauth2.Token)
+	login := ""
+	if githubUser != nil {
+		login = githubUser.Login
+	}
+	ref := r.URL.Query().Get("ref")
+	if ref == "" {
+		ref = "refs/heads/main"
+	}
+	bookmarks, sha, err := GetBookmarks(r.Context(), login, ref, token)
+	if err != nil {
+		return fmt.Errorf("GetBookmarks: %w", err)
+	}
+	list := ParseBookmarks(bookmarks)
+	for _, t := range list {
+		if t.DisplayName() == tabName || t.Name == tabName {
+			if pageIdx < len(t.Pages) {
+				page := t.Pages[pageIdx]
+				for _, blk := range page.Blocks {
+					for _, col := range blk.Columns {
+						for _, c := range col.Categories {
+							if c.Index == catIdx {
+								c.MoveEntry(from, to)
+								break
+							}
+						}
+					}
+				}
+			}
+			break
+		}
+	}
+	if err := UpdateBookmarks(r.Context(), login, token, ref, "main", list.String(), sha); err != nil {
+		return fmt.Errorf("updateBookmarks: %w", err)
+	}
+	return nil
+}

--- a/templates/dragdrop.gohtml
+++ b/templates/dragdrop.gohtml
@@ -1,0 +1,49 @@
+{{define "dragdrop"}}
+<script>
+function enableDragSort(list, buildUrl) {
+    if (!list) return;
+    let dragEl;
+    list.querySelectorAll('li').forEach(li => {
+        const handle = li.querySelector('.move-handle') || li;
+        handle.draggable = true;
+        handle.addEventListener('dragstart', e => {
+            dragEl = li;
+            e.dataTransfer.effectAllowed = 'move';
+        });
+        li.addEventListener('dragover', e => {
+            e.preventDefault();
+            e.dataTransfer.dropEffect = 'move';
+        });
+        li.addEventListener('drop', e => {
+            e.preventDefault();
+            if (dragEl && dragEl !== li) {
+                const items = Array.from(list.children);
+                const from = items.indexOf(dragEl);
+                const to = items.indexOf(li);
+                if (from >= 0 && to >= 0) {
+                    if (from < to) {
+                        li.after(dragEl);
+                    } else {
+                        li.before(dragEl);
+                    }
+                    fetch(buildUrl(from, to), {method:'POST'}).then(() => location.reload());
+                }
+            }
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const tabList = document.getElementById('tab-list');
+    enableDragSort(tabList, (f,t)=>`/moveTab?from=${f}&to=${t}`);
+    const pageList = document.getElementById('page-list');
+    const currentTab = document.body.dataset.tab || '';
+    enableDragSort(pageList, (f,t)=>`/movePage?tab=${encodeURIComponent(currentTab)}&from=${f}&to=${t}`);
+    document.querySelectorAll('.bookmark-entries').forEach(ul => {
+        const cat = ul.dataset.index;
+        const page = ul.dataset.page;
+        enableDragSort(ul, (f,t)=>`/moveEntry?category=${cat}&page=${page}&tab=${encodeURIComponent(currentTab)}&from=${f}&to=${t}`);
+    });
+});
+</script>
+{{end}}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -11,7 +11,7 @@
             <meta http-equiv="refresh" content="1">
         {{ end }}
         </head>
-        <body{{if $.EditMode}} class="edit-mode"{{end}}>
+        <body{{if $.EditMode}} class="edit-mode"{{end}}{{if tab}} data-tab="{{tab}}"{{end}}>
                 <table border=0 id="layout">
                         <tr valign=top>
                                 <td width=200px id="nav">
@@ -23,16 +23,20 @@
                                                 <a href="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
                                                 {{if $.EditMode}}{{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>{{end}}
                                                 <hr/>
-                                                <b>Tabs</b><br/>
-                                                <a href="/">Main</a><br/>
-                                                {{- range bookmarkTabs }}
-                                                        <a href="/?tab={{ . }}">{{ . }}</a><br/>
-                                                {{- end }}
+                                                <b>Tabs</b>
+                                                <ul id="tab-list" style="list-style-type:none;padding-left:0;">
+                                                        <li><span class="move-handle">&#9776;</span><a href="/">Main</a></li>
+                                                        {{- range bookmarkTabs }}
+                                                                <li><span class="move-handle">&#9776;</span><a href="/?tab={{ . }}">{{ . }}</a></li>
+                                                        {{- end }}
+                                                </ul>
                                                 <hr/>
-                                                <b>Pages</b><br/>
-                                                {{- range $i, $p := bookmarkPages }}
-                                                        <a href="#page{{$i}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a><br/>
-                                                {{- end }}
+                                                <b>Pages</b>
+                                                <ul id="page-list" style="list-style-type:none;padding-left:0;">
+                                                        {{- range $i, $p := bookmarkPages }}
+                                                                <li><span class="move-handle">&#9776;</span><a href="#page{{$i}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                        {{- end }}
+                                                </ul>
                                         {{ else }}
                                                 <a href="/login">Login</a><br/>
                                         {{ end }}

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -20,9 +20,10 @@
                     {{- range .Categories }}
                         <div class="categoryBlock">
                             <h2>{{ .DisplayName }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
-                            <ul  style="list-style-type: none;">
-                                {{- range .Entries }}
+                            <ul class="bookmark-entries" data-index="{{ .Index }}" data-page="{{$i}}" style="list-style-type: none;">
+                                {{- range $j, $e := .Entries }}
                                     <li>
+                                        <span class="move-handle">&#9776;</span>
                                         <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
                                         <a href="{{ .Url }}" target="_blank">{{ .DisplayName }}</a>
                                     </li>
@@ -39,10 +40,11 @@
                     {{- range .Columns }}
                     <td>
                         {{- range .Categories }}
-                            <ul  style="list-style-type: none;">
+                            <ul class="bookmark-entries" data-index="{{ .Index }}" data-page="{{$i}}" style="list-style-type: none;">
                                 <h2>{{ .DisplayName }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
-                                {{- range .Entries }}
+                                {{- range $j, $e := .Entries }}
                                     <li>
+                                        <span class="move-handle">&#9776;</span>
                                         <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
                                         <a href="{{ .Url }}" target="_blank">{{ .DisplayName }}</a>
                                     </li>
@@ -59,4 +61,5 @@
         {{- end }}
         <p><a href="/editTab?ref={{ref}}&tab={{tab}}">Add Tab</a></p>
     {{end}}
+{{ template "dragdrop" $ }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- add JS for drag/drop reordering
- embed dragdrop.js and serve it
- add endpoints to move tabs/pages/links
- support moving entries, pages and tabs in bookmark model
- expose sortable lists in templates
- test new move methods
- add move handles and limit drag to icon

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68529c398808832f856e69fabaeae1b2