### PR TITLE
Fix removal of empty columns when moving categories

### DIFF
--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -417,6 +417,7 @@ func (tabs BookmarkList) MoveCategory(fromIndex, toIndex int, newColumn bool, de
 		beforeLoc.catIdx--
 	}
 
+	var destColumn *BookmarkColumn
 	if beforeLoc == nil { // append to end or specified column
 		destBlock := cats[len(cats)-1].block
 		destColObj := destBlock.Columns[len(destBlock.Columns)-1]
@@ -434,6 +435,7 @@ func (tabs BookmarkList) MoveCategory(fromIndex, toIndex int, newColumn bool, de
 			destBlock.Columns = append(destBlock.Columns, destColObj)
 		}
 		destColObj.Categories = append(destColObj.Categories, src.cat)
+		destColumn = destColObj
 	} else {
 		dest := *beforeLoc
 		destCol := dest.column
@@ -444,6 +446,11 @@ func (tabs BookmarkList) MoveCategory(fromIndex, toIndex int, newColumn bool, de
 			insertIdx = 0
 		}
 		destCol.InsertCategory(insertIdx, src.cat)
+		destColumn = destCol
+	}
+
+	if len(src.column.Categories) == 0 && src.column != destColumn {
+		src.block.Columns = append(src.block.Columns[:src.colIdx], src.block.Columns[src.colIdx+1:]...)
 	}
 
 	// reindex

--- a/testdata/move_category_before_expected.txt
+++ b/testdata/move_category_before_expected.txt
@@ -11,7 +11,6 @@ http://c.com c
 --
 Category: D
 http://d.com d
-Column
 Tab
 Category: F
 http://f.com f

--- a/testdata/move_category_end_expected.txt
+++ b/testdata/move_category_end_expected.txt
@@ -1,4 +1,3 @@
-Column
 Category: B
 http://b.com b
 Category: A

--- a/testdata/move_category_newcolumn_expected.txt
+++ b/testdata/move_category_newcolumn_expected.txt
@@ -1,4 +1,3 @@
-Column
 Category: B
 http://b.com b
 Page


### PR DESCRIPTION
## Summary
- remove empty columns in `MoveCategory`
- update expected outputs in `move_category_*` tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852b6dfd5a0832fb538836d50897f9f