### PR TITLE
Remove Add Tab link from index page

### DIFF
--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -65,7 +65,6 @@
             {{- end }}
         </div>
         {{- end }}
-        <p><a href="/editTab?ref={{ref}}&tab={{tab}}">Add Tab</a></p>
         {{ if $.EditMode }}
         <script>
         document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- remove stray **Add Tab** link at bottom of index page

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852bc22bd3c832fb8bd54373f9dc52d