### PR TITLE
Fix category move SHA updates

### DIFF
--- a/templates/dragdrop.gohtml
+++ b/templates/dragdrop.gohtml
@@ -26,7 +26,7 @@ function enableDragSort(list, buildUrl) {
                     } else {
                         li.before(dragEl);
                     }
-                    fetch(buildUrl(from, to), {method:'POST'}).then(() => location.reload());
+                    postWithReload(buildUrl(from, to), {method:'POST'});
                 }
             }
         });

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -68,6 +68,16 @@
         <p><a href="/editTab?ref={{ref}}&tab={{tab}}">Add Tab</a></p>
         {{ if $.EditMode }}
         <script>
+        function postWithReload(url, options) {
+            fetch(url, options).then(function(resp) {
+                if (!resp.ok) {
+                    return resp.text().then(function(t) { alert(t); });
+                }
+            }).catch(function(err) {
+                alert(err);
+            }).finally(function() { location.reload(); });
+        }
+
         document.addEventListener('DOMContentLoaded', function () {
             if (!document.body.classList.contains('edit-mode')) return;
 
@@ -174,7 +184,7 @@
                 fd.append('ref', ref);
                 if (destSha) fd.append('destPageSha', destSha);
                 if (destCol !== null) fd.append('destCol', destCol);
-                fetch('/moveCategory', {method: 'POST', body: fd, credentials: 'same-origin'});
+                postWithReload('/moveCategory', {method: 'POST', body: fd, credentials: 'same-origin'});
             }
 
             function sendMoveEnd(from, pageSha, destSha, destCol) {
@@ -198,7 +208,7 @@
                 fd.append('ref', ref);
                 if (destSha) fd.append('destPageSha', destSha);
                 if (destCol !== null) fd.append('destCol', destCol);
-                fetch('/moveCategoryEnd', {method: 'POST', body: fd, credentials: 'same-origin'});
+                postWithReload('/moveCategoryEnd', {method: 'POST', body: fd, credentials: 'same-origin'});
             }
 
             function sendMoveNewColumn(from, pageSha, destSha) {
@@ -221,7 +231,7 @@
                 fd.append('branch', branch);
                 fd.append('ref', ref);
                 if (destSha) fd.append('destPageSha', destSha);
-                fetch('/moveCategoryNewColumn', {method: 'POST', body: fd, credentials: 'same-origin'});
+                postWithReload('/moveCategoryNewColumn', {method: 'POST', body: fd, credentials: 'same-origin'});
             }
 
             function dragOver(e) {


### PR DESCRIPTION
## Summary
- reload the page after moving categories so the SHA is refreshed
- show any move errors before reloading

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852bbf498c0832f9ff1b6fc34fc57db