### PR TITLE
Fix page links while editing

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -56,6 +56,7 @@ func testFuncMap() template.FuncMap {
 		"bookmarkTabs":       func() ([]TabInfo, error) { return []TabInfo{{Index: 0, Name: "Main", Href: "/"}}, nil },
 		"useCssColumns":      func() bool { return false },
 		"showFooter":         func() bool { return true },
+		"showPages":          func() bool { return true },
 		"loggedIn":           func() (bool, error) { return true, nil },
 		"commitShort": func() string {
 			short := commit

--- a/funcs.go
+++ b/funcs.go
@@ -97,6 +97,24 @@ func NewFuncs(r *http.Request) template.FuncMap {
 		"showFooter": func() bool {
 			return !NoFooter
 		},
+		"showPages": func() bool {
+			if r == nil {
+				return false
+			}
+			if strings.HasPrefix(r.URL.Path, "/login") || r.URL.Path == "/status" {
+				return false
+			}
+			sessioni := r.Context().Value(ContextValues("session"))
+			session, ok := sessioni.(*sessions.Session)
+			if !ok || session == nil {
+				return false
+			}
+			githubUser, ok := session.Values["GithubUser"].(*User)
+			if !ok || githubUser == nil {
+				return false
+			}
+			return true
+		},
 		"loggedIn": func() (bool, error) {
 			session := r.Context().Value(ContextValues("session")).(*sessions.Session)
 			githubUser, ok := session.Values["GithubUser"].(*User)

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -33,7 +33,7 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                                <li><span class="move-handle">&#9776;</span><a href="#page{{$i}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                                <li><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                 </ul>
                                         {{ else }}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -30,12 +30,14 @@
                                                         {{- end }}
                                                 </ul>
                                                 <hr/>
+                                                {{ if showPages }}
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
                                                                 <li><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                 </ul>
+                                                {{ end }}
                                         {{ else }}
                                                 <a href="/login">Login</a><br/>
                                         {{ end }}


### PR DESCRIPTION
## Summary
- direct page links to the correct tab when editing

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852c5fae100832f83b6dca6ff77a815