### PR TITLE
Use IndexName for navigation

### DIFF
--- a/bookmarkNames.go
+++ b/bookmarkNames.go
@@ -50,6 +50,11 @@ func (p *BookmarkPage) DisplayName() string {
 	return ""
 }
 
+// IndexName returns a name suitable for the navigation index.
+func (p *BookmarkPage) IndexName() string {
+	return p.DisplayName()
+}
+
 // DisplayName returns a useful name for the tab.
 func (t *BookmarkTab) DisplayName() string {
 	if strings.TrimSpace(t.Name) != "" {
@@ -68,4 +73,9 @@ func (t *BookmarkTab) DisplayName() string {
 		}
 	}
 	return ""
+}
+
+// IndexName returns a name suitable for the navigation index.
+func (t *BookmarkTab) IndexName() string {
+	return t.DisplayName()
 }

--- a/data_test.go
+++ b/data_test.go
@@ -53,10 +53,12 @@ func testFuncMap() template.FuncMap {
 		"tab":                func() string { return "0" },
 		"tabName":            func() string { return "Main" },
 		"page":               func() string { return "" },
-		"bookmarkTabs":       func() ([]TabInfo, error) { return []TabInfo{{Index: 0, Name: "Main", Href: "/"}}, nil },
-		"useCssColumns":      func() bool { return false },
-		"showFooter":         func() bool { return true },
-		"loggedIn":           func() (bool, error) { return true, nil },
+		"bookmarkTabs": func() ([]TabInfo, error) {
+			return []TabInfo{{Index: 0, Name: "", IndexName: "Main", Href: "/"}}, nil
+		},
+		"useCssColumns": func() bool { return false },
+		"showFooter":    func() bool { return true },
+		"loggedIn":      func() (bool, error) { return true, nil },
 		"commitShort": func() string {
 			short := commit
 			if len(short) > 7 {

--- a/funcs.go
+++ b/funcs.go
@@ -14,9 +14,10 @@ import (
 
 // TabInfo is used by templates to display tab navigation with indexes.
 type TabInfo struct {
-	Index int
-	Name  string
-	Href  string
+	Index     int
+	Name      string
+	IndexName string
+	Href      string
 }
 
 var (
@@ -198,16 +199,16 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			tabsData := ParseBookmarks(bookmark)
 			var tabs []TabInfo
 			for i, t := range tabsData {
-				name := t.DisplayName()
-				if name == "" && i == 0 {
-					name = "Main"
+				indexName := t.DisplayName()
+				if indexName == "" && i == 0 {
+					indexName = "Main"
 				}
-				if name != "" {
+				if indexName != "" {
 					href := "/"
 					if i != 0 {
 						href = fmt.Sprintf("/?tab=%d", i)
 					}
-					tabs = append(tabs, TabInfo{Index: i, Name: name, Href: href})
+					tabs = append(tabs, TabInfo{Index: i, Name: t.Name, IndexName: indexName, Href: href})
 				}
 			}
 			return tabs, nil

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -26,15 +26,15 @@
                                                 <b>Tabs</b>
                                                 <ul id="tab-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range bookmarkTabs }}
-                                                                <li><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .Name }}</a></li>
+                                                       <li><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .IndexName }}</a></li>
                                                         {{- end }}
                                                 </ul>
                                                 <hr/>
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
-                                                        {{- range $i, $p := bookmarkPages }}
-                                                                <li><span class="move-handle">&#9776;</span><a href="#page{{$i}}">Page {{ if $p.DisplayName }}{{$p.DisplayName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
-                                                        {{- end }}
+                                                       {{- range $i, $p := bookmarkPages }}
+                                                               <li><span class="move-handle">&#9776;</span><a href="#page{{$i}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                       {{- end }}
                                                 </ul>
                                         {{ else }}
                                                 <a href="/login">Login</a><br/>

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -8,7 +8,7 @@
         {{- range $i, $p := bookmarkPages }}
         <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{$i}}" data-sha="{{$p.Sha}}">
             {{- if and (eq $i 0) tab }}<h1>{{ tabName }} <a class="edit-link" href="/editTab?name={{ tabName }}&ref={{ref}}&tab={{tab}}" title="Edit">&#9998;</a></h1>{{ end }}
-            {{- if $p.DisplayName }}<h2>{{ $p.DisplayName }}</h2>{{ end }}
+            {{- if $p.Name }}<h2>{{ $p.Name }}</h2>{{ end }}
             {{- range .Blocks }}
             {{- if .HR }}
             <hr class="bookmarkHr" />


### PR DESCRIPTION
## Summary
- rename `DisplayName` navigation field to `IndexName`
- expose `IndexName()` helpers for page and tab
- switch templates to use `IndexName`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6852c237d110832f815b5580b7d398e5