### PR TITLE
Limit drag handles to edit mode

### DIFF
--- a/main.css
+++ b/main.css
@@ -206,3 +206,7 @@ body:not(.edit-mode) .categoryBlock h2 {
 body:not(.edit-mode) .moveIcon {
     display: none;
 }
+
+body:not(.edit-mode) .move-handle {
+    display: none;
+}

--- a/templates/dragdrop.gohtml
+++ b/templates/dragdrop.gohtml
@@ -34,6 +34,7 @@ function enableDragSort(list, buildUrl) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    if (!document.body.classList.contains('edit-mode')) return;
     const tabList = document.getElementById('tab-list');
     enableDragSort(tabList, (f,t)=>`/moveTab?from=${f}&to=${t}`);
     const pageList = document.getElementById('page-list');

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -323,5 +323,7 @@
         </script>
         {{ end }}
     {{end}}
+{{ if $.EditMode }}
 {{ template "dragdrop" $ }}
+{{ end }}
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- ensure move handles are hidden when not editing
- guard drag-and-drop script behind edit mode check
- only include dragdrop template in edit mode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6852ce215128832f80816811a7bd83d8