### PR TITLE
Enable dropping categories onto index

### DIFF
--- a/bookmarkActionHandlers.go
+++ b/bookmarkActionHandlers.go
@@ -173,7 +173,10 @@ func CategoryMoveEndAction(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return fmt.Errorf("invalid from index: %w", err)
 	}
-	destCol, _ := strconv.Atoi(destColStr)
+	destCol, err := strconv.Atoi(destColStr)
+	if destColStr == "" || err != nil {
+		destCol = -1
+	}
 
 	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
 	githubUser, _ := session.Values["GithubUser"].(*User)
@@ -202,6 +205,11 @@ func CategoryMoveEndAction(w http.ResponseWriter, r *http.Request) error {
 	destPage := FindPageBySha(tabs, destPageSha)
 	if destPage == nil {
 		destPage = tabs[len(tabs)-1].Pages[len(tabs[len(tabs)-1].Pages)-1]
+	}
+
+	if destCol < 0 {
+		lastBlock := destPage.Blocks[len(destPage.Blocks)-1]
+		destCol = len(lastBlock.Columns) - 1
 	}
 
 	if err := tabs.MoveCategoryToEnd(fromIdx, destPage, destCol); err != nil {

--- a/bookmarkMove_test.go
+++ b/bookmarkMove_test.go
@@ -14,6 +14,8 @@ var (
 	moveNewColumnExpected string
 	//go:embed testdata/move_category_end_expected.txt
 	moveEndExpected string
+	//go:embed testdata/move_category_end_lastpage_expected.txt
+	moveEndLastPageExpected string
 )
 
 func TestMoveCategory(t *testing.T) {
@@ -46,5 +48,20 @@ func TestMoveCategoryEndColumn(t *testing.T) {
 	got := tabs.String()
 	if got != moveEndExpected {
 		t.Fatalf("expected %q got %q", moveEndExpected, got)
+	}
+}
+
+func TestMoveCategoryEndLastPage(t *testing.T) {
+	tabs := ParseBookmarks(moveComplexInput)
+	destPage := tabs[0].Pages[len(tabs[0].Pages)-1]
+	lastBlock := destPage.Blocks[len(destPage.Blocks)-1]
+	destCol := len(lastBlock.Columns) - 1
+	if err := tabs.MoveCategoryToEnd(0, destPage, destCol); err != nil {
+		t.Fatalf("MoveCategory: %v", err)
+	}
+	got := tabs.String()
+	expected := moveEndLastPageExpected
+	if got != expected {
+		t.Fatalf("expected %q got %q", expected, got)
 	}
 }

--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -423,14 +423,12 @@ func (tabs BookmarkList) MoveCategory(fromIndex, toIndex int, newColumn bool, de
 		destColObj := destBlock.Columns[len(destBlock.Columns)-1]
 		destColIdx := len(destBlock.Columns) - 1
 		if destPage != nil {
-			for _, b := range destPage.Blocks {
-				if destCol < len(b.Columns) {
-					destBlock = b
-					destColObj = b.Columns[destCol]
-					destColIdx = destCol
-					break
-				}
+			destBlock = destPage.Blocks[len(destPage.Blocks)-1]
+			if destCol >= len(destBlock.Columns) {
+				destCol = len(destBlock.Columns) - 1
 			}
+			destColObj = destBlock.Columns[destCol]
+			destColIdx = destCol
 		}
 		if newColumn {
 			destColIdx++

--- a/data_test.go
+++ b/data_test.go
@@ -59,7 +59,7 @@ func testFuncMap() template.FuncMap {
 		"showPages":          func() bool { return true },
 		"loggedIn":           func() (bool, error) { return true, nil },
 		"bookmarkTabs": func() ([]TabInfo, error) {
-			return []TabInfo{{Index: 0, Name: "", IndexName: "Main", Href: "/"}}, nil
+			return []TabInfo{{Index: 0, Name: "", IndexName: "Main", Href: "/", LastPageSha: ""}}, nil
 		},
 		"commitShort": func() string {
 			short := commit

--- a/funcs.go
+++ b/funcs.go
@@ -14,10 +14,11 @@ import (
 
 // TabInfo is used by templates to display tab navigation with indexes.
 type TabInfo struct {
-	Index     int
-	Name      string
-	IndexName string
-	Href      string
+	Index       int
+	Name        string
+	IndexName   string
+	Href        string
+	LastPageSha string
 }
 
 var (
@@ -226,7 +227,11 @@ func NewFuncs(r *http.Request) template.FuncMap {
 					if i != 0 {
 						href = fmt.Sprintf("/?tab=%d", i)
 					}
-					tabs = append(tabs, TabInfo{Index: i, Name: t.Name, IndexName: indexName, Href: href})
+					lastSha := ""
+					if len(t.Pages) > 0 {
+						lastSha = t.Pages[len(t.Pages)-1].Sha()
+					}
+					tabs = append(tabs, TabInfo{Index: i, Name: t.Name, IndexName: indexName, Href: href, LastPageSha: lastSha})
 				}
 			}
 			return tabs, nil

--- a/main.css
+++ b/main.css
@@ -166,6 +166,11 @@ body:not(.edit-mode) .edit-link {
     outline: 2px dotted #800000;
 }
 
+#tab-list li.drag-over,
+#page-list li.drag-over {
+    outline: 2px dotted #800000;
+}
+
 .newColumnDropZone,
 .columnEndDropZone {
     display: inline-block;

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -26,7 +26,7 @@
                                                 <b>Tabs</b>
                                                 <ul id="tab-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range bookmarkTabs }}
-                                                       <li><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .IndexName }}</a></li>
+                                                       <li data-page-sha="{{ .LastPageSha }}"><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .IndexName }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
                                                                 <li><a href="/editTab?ref={{ref}}&tab={{tab}}">+ Add Tab</a></li>
@@ -37,7 +37,7 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                              <li><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                      <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
                                                                 <li><a href="/editPage?ref={{ref}}&tab={{tab}}">+ Add Page</a></li>

--- a/templates/indexPage.gohtml
+++ b/templates/indexPage.gohtml
@@ -144,6 +144,18 @@
                 zone.addEventListener('drop', dropEndColumn);
             });
 
+            document.querySelectorAll('#page-list li[data-page-sha]').forEach(function (li) {
+                li.addEventListener('dragover', dragOver);
+                li.addEventListener('dragleave', dragLeave);
+                li.addEventListener('drop', dropOnPageIndex);
+            });
+
+            document.querySelectorAll('#tab-list li[data-page-sha]').forEach(function (li) {
+                li.addEventListener('dragover', dragOver);
+                li.addEventListener('dragleave', dragLeave);
+                li.addEventListener('drop', dropOnTabIndex);
+            });
+
             function dragStart(e) {
                 var block = e.currentTarget.closest('.categoryBlock');
                 startZone = findColumnZone(block);
@@ -316,6 +328,32 @@
                     sendMoveEnd(from, pageSha, destSha, destCol);
                     updateColumnIndices(destPage);
                     removeEmptyColumn(startZone);
+                    startZone = null;
+                }
+            }
+
+            function dropOnPageIndex(e) {
+                e.preventDefault();
+                e.currentTarget.classList.remove('drag-over');
+                var id = e.dataTransfer.getData('text/plain');
+                if (id) {
+                    var from = parseInt(id.substring(3));
+                    var pageSha = e.dataTransfer.getData('pageSha');
+                    var destSha = e.currentTarget.dataset.pageSha;
+                    sendMoveEnd(from, pageSha, destSha, -1);
+                    startZone = null;
+                }
+            }
+
+            function dropOnTabIndex(e) {
+                e.preventDefault();
+                e.currentTarget.classList.remove('drag-over');
+                var id = e.dataTransfer.getData('text/plain');
+                if (id) {
+                    var from = parseInt(id.substring(3));
+                    var pageSha = e.dataTransfer.getData('pageSha');
+                    var destSha = e.currentTarget.dataset.pageSha;
+                    sendMoveEnd(from, pageSha, destSha, -1);
                     startZone = null;
                 }
             }

--- a/testdata/move_category_end_lastpage_expected.txt
+++ b/testdata/move_category_end_lastpage_expected.txt
@@ -1,0 +1,16 @@
+Category: B
+http://b.com b
+Page
+Category: C
+http://c.com c
+--
+Category: D
+http://d.com d
+Column
+Category: E
+http://e.com e
+Category: A
+http://a.com a
+Tab
+Category: F
+http://f.com f


### PR DESCRIPTION
## Summary
- add drag-n-drop support for tab/page index items
- default server move action to last column when dropping on index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685345c2bb9c832fb045baa78f8fd472