### PR TITLE
Fix display of unnamed tabs

### DIFF
--- a/bookmarkNames.go
+++ b/bookmarkNames.go
@@ -60,14 +60,20 @@ func (t *BookmarkTab) DisplayName() string {
 	if strings.TrimSpace(t.Name) != "" {
 		return t.Name
 	}
-	if len(t.Pages) == 1 {
-		if n := t.Pages[0].DisplayName(); n != "" {
+	var pages []*BookmarkPage
+	for _, p := range t.Pages {
+		if !p.IsEmpty() {
+			pages = append(pages, p)
+		}
+	}
+	if len(pages) == 1 {
+		if n := pages[0].DisplayName(); n != "" {
 			return n
 		}
 	}
-	if len(t.Pages) == 2 {
-		n1 := t.Pages[0].DisplayName()
-		n2 := t.Pages[1].DisplayName()
+	if len(pages) == 2 {
+		n1 := pages[0].DisplayName()
+		n2 := pages[1].DisplayName()
 		if n1 != "" && n2 != "" && len(n1) <= 15 && len(n2) <= 15 {
 			return n1 + ", " + n2
 		}

--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -119,6 +119,18 @@ type BookmarkPage struct {
 	Name   string
 }
 
+// IsEmpty returns true if the page contains no categories.
+func (p *BookmarkPage) IsEmpty() bool {
+	for _, blk := range p.Blocks {
+		for _, col := range blk.Columns {
+			if len(col.Categories) > 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // String serializes the page (excluding the Page line).
 func (p *BookmarkPage) String() string {
 	var sb strings.Builder

--- a/displayname_test.go
+++ b/displayname_test.go
@@ -59,3 +59,64 @@ func TestBookmarkTabDisplayName(t *testing.T) {
 		t.Fatalf("expected empty got %q", empty.DisplayName())
 	}
 }
+
+func TestBookmarkTabDisplayNameIgnoreEmptyPages(t *testing.T) {
+	p1 := &BookmarkPage{Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{Categories: []*BookmarkCategory{{Name: "A"}}}}}}}
+	p2 := &BookmarkPage{Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}}
+	t1 := &BookmarkTab{Pages: []*BookmarkPage{p1, p2}}
+	if t1.DisplayName() != "A" {
+		t.Fatalf("expected A got %q", t1.DisplayName())
+	}
+}
+
+const exampleFailureText = `Column
+Category: Category
+http://www.google.com.au Google1
+http://www.google.com.au Google2
+http://www.google.com.au Google3
+http://www.google.com.au Google4
+http://www.google.com.au Google5
+http://www.google.com.au Google6
+Page
+Category: Category
+http://www.google.com.au Google
+http://www.google.com.au Google1
+http://www.google.com.au Google2
+http://www.google.com.au Google3
+http://www.google.com.au Google4
+http://www.google.com.au Google5
+http://www.google.com.au Google6
+Tab
+Category: hi
+http://b.com b
+Category: Example
+http://www.google.com.au Google1
+http://www.google.com.au Google2
+http://www.google.com.au Google3
+http://www.google.com.au Google4
+http://www.google.com.au Google5
+http://www.google.com.au Google6
+Page
+Tab
+Category: hi
+http://b.com b
+Tab
+Category: hii
+http://b.com b
+Column
+Category: Test
+https://hi.com hi
+Page`
+
+func TestBookmarkTabDisplayNameExampleFailure(t *testing.T) {
+	tabs := ParseBookmarks(exampleFailureText)
+	if len(tabs) != 4 {
+		t.Fatalf("expected 4 tabs got %d", len(tabs))
+	}
+	names := []string{"Category, Category", "hi, Example", "hi", "hii, Test"}
+	for i, name := range names {
+		if tabs[i].DisplayName() != name {
+			t.Fatalf("tab %d expected %q got %q", i, name, tabs[i].DisplayName())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `IsEmpty` helper for pages
- ignore empty pages when determining tab display names
- test tab display names with empty pages
- add regression test with provided sample data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6853624cf554832fb3c6567ccb88393e