### PR TITLE
Preserve redirect parameters using context

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -266,8 +266,8 @@ func main() {
 	r.HandleFunc("/edit", runHandlerChain(BookmarksEditCreateAction, redirectToHandlerBranchToRef("/"))).Methods("POST").MatcherFunc(RequiresAnAccount()).MatcherFunc(TaskMatcher("Create"))
 	r.HandleFunc("/edit", runHandlerChain(TaskDoneAutoRefreshPage)).Methods("POST")
 
-	r.HandleFunc("/startEditMode", runHandlerChain(StartEditMode, redirectToHandler("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
-	r.HandleFunc("/stopEditMode", runHandlerChain(StopEditMode, redirectToHandler("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/startEditMode", runHandlerChain(StartEditMode, redirectToHandlerTabPage("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
+	r.HandleFunc("/stopEditMode", runHandlerChain(StopEditMode, redirectToHandlerTabPage("/"))).Methods("POST", "GET").MatcherFunc(RequiresAnAccount())
 
 	r.HandleFunc("/editCategory", runTemplate("loginPage.gohtml")).Methods("GET").MatcherFunc(gorillamuxlogic.Not(RequiresAnAccount()))
 	r.HandleFunc("/editCategory", runHandlerChain(EditCategoryPage)).Methods("GET").MatcherFunc(RequiresAnAccount())
@@ -518,10 +518,33 @@ func redirectToHandlerBranchToRef(toUrl string) func(http.ResponseWriter, *http.
 		u, _ := url.Parse(toUrl)
 		qs := u.Query()
 		qs.Set("ref", "refs/heads/"+r.PostFormValue("branch"))
-		if tab := r.PostFormValue("tab"); tab != "" {
+		tab := r.PostFormValue("tab")
+		if v, ok := r.Context().Value(ContextValues("redirectTab")).(string); ok {
+			tab = v
+		}
+		if tab != "" {
 			qs.Set("tab", tab)
 		}
-		if page := r.PostFormValue("page"); page != "" {
+		page := r.PostFormValue("page")
+		if v, ok := r.Context().Value(ContextValues("redirectPage")).(string); ok {
+			page = v
+		}
+		if page != "" {
+			u.Fragment = "page" + page
+		}
+		u.RawQuery = qs.Encode()
+		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
+	})
+}
+
+func redirectToHandlerTabPage(toUrl string) func(http.ResponseWriter, *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, _ := url.Parse(toUrl)
+		qs := u.Query()
+		if tab := r.URL.Query().Get("tab"); tab != "" {
+			qs.Set("tab", tab)
+		}
+		if page := r.URL.Query().Get("page"); page != "" {
 			u.Fragment = "page" + page
 		}
 		u.RawQuery = qs.Encode()

--- a/pageEditHandlers.go
+++ b/pageEditHandlers.go
@@ -1,6 +1,7 @@
 package gobookmarks
 
 import (
+	"context"
 	"fmt"
 	"github.com/gorilla/sessions"
 	"golang.org/x/oauth2"
@@ -73,6 +74,7 @@ func PageEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 	if tabIdx < 0 || tabIdx >= len(list) {
 		tabIdx = 0
 	}
+	newIndex := len(list[tabIdx].Pages)
 	parsed := ParseBookmarks("Tab\nPage: " + name + "\n" + text)
 	p := parsed[0].Pages[0]
 	list[tabIdx].AddPage(p)
@@ -80,5 +82,10 @@ func PageEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, list.String(), curSha); err != nil {
 		return fmt.Errorf("updateBookmark error: %w", err)
 	}
+
+	ctx := context.WithValue(r.Context(), ContextValues("redirectTab"), strconv.Itoa(tabIdx))
+	ctx = context.WithValue(ctx, ContextValues("redirectPage"), strconv.Itoa(newIndex))
+	*r = *r.WithContext(ctx)
+
 	return nil
 }

--- a/tabEditHandlers.go
+++ b/tabEditHandlers.go
@@ -1,10 +1,12 @@
 package gobookmarks
 
 import (
+	"context"
 	"fmt"
 	"github.com/gorilla/sessions"
 	"golang.org/x/oauth2"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -85,6 +87,7 @@ func TabEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	var updated string
+	newIndex := len(ParseBookmarks(currentBookmarks))
 	if oldName == "" {
 		updated = AppendTab(currentBookmarks, name, text)
 	} else {
@@ -96,6 +99,11 @@ func TabEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 
 	if err := UpdateBookmarks(r.Context(), login, token, ref, branch, updated, curSha); err != nil {
 		return fmt.Errorf("updateBookmark error: %w", err)
+	}
+	if oldName == "" {
+		ctx := context.WithValue(r.Context(), ContextValues("redirectTab"), strconv.Itoa(newIndex))
+		ctx = context.WithValue(ctx, ContextValues("redirectPage"), "0")
+		*r = *r.WithContext(ctx)
 	}
 	return nil
 }

--- a/templates/editPage.gohtml
+++ b/templates/editPage.gohtml
@@ -11,6 +11,7 @@
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
         <input type=hidden name="tab" value="{{tab}}" />
+        {{if page}}<input type=hidden name="page" value="{{page}}" />{{end}}
     </form>
     {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/editTab.gohtml
+++ b/templates/editTab.gohtml
@@ -10,7 +10,8 @@
         <input type=submit name="task" value="Save" /><br>
         <input type=hidden name="ref" value="{{ref}}" />
         <input type=hidden name="sha" value="{{bookmarksSHA}}" />
-        <input type=hidden name="tab" value="{{tab}}" />
+        {{if tab}}<input type=hidden name="tab" value="{{tab}}" />{{end}}
+        {{if page}}<input type=hidden name="page" value="{{page}}" />{{end}}
     </form>
     {{ template "editNotes" $ }}
 {{ template "tail" $ }}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -20,7 +20,7 @@
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>
                                                 <a href="/history">History</a><br/>
-                                                <a href="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
+                                                <a id="toggle-edit" href="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}{{if tab}}?tab={{tab}}{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
                                                 {{if $.EditMode}}{{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>{{end}}
                                                 <hr/>
                                                 <b>Tabs</b>
@@ -29,7 +29,7 @@
                                                        <li><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .IndexName }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
-                                                                <li><a href="/editTab?ref={{ref}}&tab={{tab}}">+ Add Tab</a></li>
+                                                                <li><a href="/editTab?ref={{ref}}">+ Add Tab</a></li>
                                                         {{- end }}
                                                 </ul>
                                                 <hr/>
@@ -37,7 +37,7 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                              <li><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                              <li><span class="move-handle">&#9776;</span><a href="/?{{if tab}}tab={{tab}}&{{end}}page={{$i}}#page{{$i}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
                                                                 <li><a href="/editPage?ref={{ref}}&tab={{tab}}">+ Add Page</a></li>

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -14,8 +14,44 @@
                                        <br><a href="/status">Status</a>
                                </i>
                        </div>
-                </footer>
+</footer>
                 {{ end }}
+                <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                    var toggleEdit = document.getElementById('toggle-edit');
+
+                    function currentPage() {
+                        var pages = document.querySelectorAll('.bookmarkPage[id^="page"]');
+                        var closest = -1;
+                        var closestDist = Infinity;
+                        pages.forEach(function (p, idx) {
+                            var rect = p.getBoundingClientRect();
+                            var dist = Math.abs(rect.top);
+                            if (dist < closestDist) {
+                                closestDist = dist;
+                                closest = idx;
+                            }
+                        });
+                        return closest;
+                    }
+
+                    function attach(link) {
+                        if (!link) return;
+                        link.addEventListener('click', function (e) {
+                            var page = currentPage();
+                            if (page >= 0) {
+                                var url = new URL(link.getAttribute('href'), window.location);
+                                url.searchParams.set('page', page);
+                                url.hash = 'page' + page;
+                                e.preventDefault();
+                                window.location.href = url.toString();
+                            }
+                        });
+                    }
+
+                    attach(toggleEdit);
+                });
+                </script>
                  </body>
 </html>
 {{end}}


### PR DESCRIPTION
## Summary
- store new tab and page indices in request context during saves
- update redirect helper to read context for tab/page

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68534584b384832fa6c9b1911aa0e03a