### PR TITLE
Switch edit mode to URL parameter

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -542,6 +542,9 @@ func redirectToHandlerBranchToRef(toUrl string) func(http.ResponseWriter, *http.
 		if page != "" {
 			u.Fragment = "page" + page
 		}
+		if edit := r.URL.Query().Get("edit"); edit != "" {
+			qs.Set("edit", edit)
+		}
 		u.RawQuery = qs.Encode()
 		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)
 	})
@@ -556,6 +559,9 @@ func redirectToHandlerTabPage(toUrl string) func(http.ResponseWriter, *http.Requ
 		}
 		if page := r.URL.Query().Get("page"); page != "" {
 			u.Fragment = "page" + page
+		}
+		if edit := r.URL.Query().Get("edit"); edit != "" {
+			qs.Set("edit", edit)
 		}
 		u.RawQuery = qs.Encode()
 		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)

--- a/core.go
+++ b/core.go
@@ -37,7 +37,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 		}
 
 		ctx := context.WithValue(request.Context(), ContextValues("provider"), providerName)
-		editMode, _ := session.Values["editMode"].(bool)
+		editMode := request.URL.Query().Get("edit") == "1"
 		ctx = context.WithValue(ctx, ContextValues("coreData"), &CoreData{
 			UserRef:  login,
 			Title:    title,

--- a/editModeHandlers.go
+++ b/editModeHandlers.go
@@ -1,27 +1,21 @@
 package gobookmarks
 
 import (
-	"fmt"
-	"github.com/gorilla/sessions"
 	"net/http"
 )
 
-// StartEditMode enables edit mode by storing a flag in the user's session.
+// StartEditMode enables edit mode by adding an "edit=1" query parameter.
 func StartEditMode(w http.ResponseWriter, r *http.Request) error {
-	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
-	session.Values["editMode"] = true
-	if err := session.Save(r, w); err != nil {
-		return fmt.Errorf("session save: %w", err)
-	}
+	qs := r.URL.Query()
+	qs.Set("edit", "1")
+	r.URL.RawQuery = qs.Encode()
 	return nil
 }
 
-// StopEditMode disables edit mode and clears the flag from the session.
+// StopEditMode disables edit mode by removing the "edit" query parameter.
 func StopEditMode(w http.ResponseWriter, r *http.Request) error {
-	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
-	delete(session.Values, "editMode")
-	if err := session.Save(r, w); err != nil {
-		return fmt.Errorf("session save: %w", err)
-	}
+	qs := r.URL.Query()
+	qs.Del("edit")
+	r.URL.RawQuery = qs.Encode()
 	return nil
 }

--- a/editModeHandlers_test.go
+++ b/editModeHandlers_test.go
@@ -27,8 +27,8 @@ func TestEditModeToggle(t *testing.T) {
 	if err := StartEditMode(w, req); err != nil {
 		t.Fatalf("StartEditMode: %v", err)
 	}
-	if v, ok := session.Values["editMode"].(bool); !ok || !v {
-		t.Fatalf("edit mode not enabled in session")
+	if req.URL.Query().Get("edit") != "1" {
+		t.Fatalf("edit mode query not set")
 	}
 
 	var cd *CoreData
@@ -46,7 +46,7 @@ func TestEditModeToggle(t *testing.T) {
 	if err := StopEditMode(w, req); err != nil {
 		t.Fatalf("StopEditMode: %v", err)
 	}
-	if v, ok := session.Values["editMode"].(bool); ok && v {
+	if req.URL.Query().Get("edit") != "" {
 		t.Fatalf("edit mode flag should be cleared")
 	}
 

--- a/templates/edit.gohtml
+++ b/templates/edit.gohtml
@@ -4,7 +4,7 @@
             Error: {{ $.Error }}
         </p>
     {{ end }}
-    <form method=post action="?" class="edit-form">
+    <form method=post action="?{{if $.EditMode}}edit=1{{end}}" class="edit-form">
         <label for="code">Code</label><br/>
         <textarea id="code" name="text" rows="30">{{bookmarksOrEditBookmarks}}</textarea><br>
         <label for="branch">Branch</label>: <input id="branch" type="text" name="branch" value="{{ branchOrEditBranch }}" /><br>

--- a/templates/editCategory.gohtml
+++ b/templates/editCategory.gohtml
@@ -2,7 +2,7 @@
     {{ if $.Error }}
         <p style="color: #FF0000">Error: {{ $.Error }}</p>
     {{ end }}
-    <form method=post action="?index={{$.Index}}" class="edit-form category-form">
+    <form method=post action="?{{if $.EditMode}}edit=1&{{end}}index={{$.Index}}" class="edit-form category-form">
         <label for="code">Category</label><br/>
         <textarea id="code" name="text" rows="10">{{$.Text}}</textarea><br>
         <input type=hidden name="branch" value="{{ branchOrEditBranch }}" />

--- a/templates/editPage.gohtml
+++ b/templates/editPage.gohtml
@@ -2,7 +2,7 @@
     {{ if $.Error }}
         <p style="color: #FF0000">Error: {{ $.Error }}</p>
     {{ end }}
-    <form method=post action="?" class="edit-form page-form">
+    <form method=post action="?{{if $.EditMode}}edit=1{{end}}" class="edit-form page-form">
         <label for="name">Name</label>: <input id="name" type="text" name="name" value="{{$.Name}}" /><br>
         <label for="code">Page Contents</label><br/>
         <textarea id="code" name="text" rows="10">{{$.Text}}</textarea><br>

--- a/templates/editTab.gohtml
+++ b/templates/editTab.gohtml
@@ -2,7 +2,7 @@
     {{ if $.Error }}
         <p style="color: #FF0000">Error: {{ $.Error }}</p>
     {{ end }}
-    <form method=post action="?name={{$.OldName}}" class="edit-form tab-form">
+    <form method=post action="?{{if $.EditMode}}edit=1&{{end}}name={{$.OldName}}" class="edit-form tab-form">
         <label for="name">Name</label>: <input id="name" type="text" name="name" value="{{$.Name}}" /><br>
         <label for="code">Tab Contents</label><br/>
         <textarea id="code" name="text" rows="10">{{$.Text}}</textarea><br>

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -20,16 +20,16 @@
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>
                                                 <a href="/history">History</a><br/>
-                                                <a id="toggle-edit" href="/{{if $.EditMode}}stopEditMode{{else}}startEditMode{{end}}{{if tab}}?tab={{tab}}{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
-                                                {{if $.EditMode}}{{if ref}}<a href="/edit?ref={{ref}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a>{{else}}<a href="/edit?{{if tab}}tab={{tab}}{{end}}">Edit All</a>{{end}}<br/>{{end}}
+                                                <a id="toggle-edit" href="/?{{if $.EditMode}}{{if tab}}tab={{tab}}{{end}}{{else}}edit=1{{if tab}}&tab={{tab}}{{end}}{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
+                                                {{if $.EditMode}}<a href="/edit?edit=1{{if ref}}&ref={{ref}}{{end}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a><br/>{{end}}
                                                 <hr/>
                                                 <b>Tabs</b>
                                                 <ul id="tab-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range bookmarkTabs }}
-                                                       <li data-page-sha="{{ .LastPageSha }}"><span class="move-handle">&#9776;</span><a href="{{ .Href }}">{{ .IndexName }}</a></li>
+                                                       <li data-page-sha="{{ .LastPageSha }}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}{{if eq .Href "/"}}/?edit=1{{else}}{{.Href}}&edit=1{{end}}{{else}}{{.Href}}{{end}}">{{ .IndexName }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
-                                                                <li><a href="/editTab?ref={{ref}}">+ Add Tab</a></li>
+                                                                <li><a href="/editTab?edit=1&ref={{ref}}">+ Add Tab</a></li>
                                                         {{- end }}
                                                 </ul>
                                                 <hr/>
@@ -37,10 +37,10 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                              <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?{{if tab}}tab={{tab}}&{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                              <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?edit=1{{if tab}}&tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
-                                                                <li><a href="/editPage?ref={{ref}}&tab={{tab}}">+ Add Page</a></li>
+                                                                <li><a href="/editPage?edit=1&ref={{ref}}&tab={{tab}}">+ Add Page</a></li>
                                                         {{- end }}
                                                 </ul>
                                                 {{ end }}

--- a/templates/mainPage.gohtml
+++ b/templates/mainPage.gohtml
@@ -7,7 +7,7 @@
         {{- end }}
         {{- range $i, $p := bookmarkPages }}
         <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{$i}}" data-sha="{{$p.Sha}}">
-            {{- if and (eq $i 0) tab }}<h1>{{ tabName }} <a class="edit-link" href="/editTab?name={{ tabName }}&ref={{ref}}&tab={{tab}}" title="Edit">&#9998;</a></h1>{{ end }}
+            {{- if and (eq $i 0) tab }}<h1>{{ tabName }} <a class="edit-link" href="/editTab?edit=1&name={{ tabName }}&ref={{ref}}&tab={{tab}}" title="Edit">&#9998;</a></h1>{{ end }}
             {{- if $p.Name }}<h2>{{ $p.Name }}</h2>{{ end }}
             {{- range .Blocks }}
             {{- if .HR }}
@@ -19,7 +19,7 @@
                     {{- if not $first }}<div class="columnBreak"></div>{{ end }}
                     {{- range $c.Categories }}
                         <div class="categoryBlock" id="cat{{ .Index }}">
-                            <h2><span class="moveIcon" title="Move">⯎</span>{{ .DisplayName }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
+                            <h2><span class="moveIcon" title="Move">⯎</span>{{ .DisplayName }} <a class="edit-link" href="/editCategory?edit=1&index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
                             <ul class="bookmark-entries" data-index="{{ .Index }}" data-page="{{$i}}" style="list-style-type: none;">
                                 {{- range $j, $e := .Entries }}
                                     <li>
@@ -32,7 +32,7 @@
                         </div>
                     {{- end }}
                     <div class="columnEndDropZone" data-col="{{$ci}}">
-                        {{- if $.EditMode }}<a class="add-category-link" href="/addCategory?ref={{ref}}&tab={{tab}}&page={{$i}}&col={{$ci}}">+ Add Category</a>{{- end }}
+                        {{- if $.EditMode }}<a class="add-category-link" href="/addCategory?edit=1&ref={{ref}}&tab={{tab}}&page={{$i}}&col={{$ci}}">+ Add Category</a>{{- end }}
                     </div>
                     <div class="newColumnDropZone" data-col="{{$ci}}"></div>
                     {{- $first = false }}
@@ -45,7 +45,7 @@
                     <td>
                         {{- range $c.Categories }}
                             <div class="categoryBlock" id="cat{{ .Index }}">
-                                <h2><span class="moveIcon" title="Move">⯎</span>{{ .DisplayName }} <a class="edit-link" href="/editCategory?index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
+                                <h2><span class="moveIcon" title="Move">⯎</span>{{ .DisplayName }} <a class="edit-link" href="/editCategory?edit=1&index={{ .Index }}&ref={{ref}}&tab={{tab}}&page={{$i}}" title="Edit">&#9998;</a></h2>
                                 <ul class="bookmark-entries" data-index="{{ .Index }}" data-page="{{$i}}" style="list-style-type: none;">
                                   {{- range $j, $e := .Entries }}
                                       <li>
@@ -58,7 +58,7 @@
                             </div>
                         {{- end }}
                         <div class="columnEndDropZone" data-col="{{$ci}}">
-                            {{- if $.EditMode }}<a class="add-category-link" href="/addCategory?ref={{ref}}&tab={{tab}}&page={{$i}}&col={{$ci}}">+ Add Category</a>{{- end }}
+                            {{- if $.EditMode }}<a class="add-category-link" href="/addCategory?edit=1&ref={{ref}}&tab={{tab}}&page={{$i}}&col={{$ci}}">+ Add Category</a>{{- end }}
                         </div>
                     </td>
                     <td class="newColumnDropZone" data-col="{{$ci}}"></td>


### PR DESCRIPTION
## Summary
- make edit mode toggle update URL query instead of session
- pull `edit` flag from query in CoreAdderMiddleware
- pass edit flag through redirect helpers
- update templates to keep `edit=1` when navigating in edit mode
- adjust edit mode tests

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858c692d164832f9e340b615d43a38e