### PR TITLE
Remove arran4 branding from default title

### DIFF
--- a/core.go
+++ b/core.go
@@ -30,7 +30,7 @@ func CoreAdderMiddleware(next http.Handler) http.Handler {
 
 		title := SiteTitle
 		if title == "" {
-			title = "Arran4's Bookmarks Website"
+			title = "gobookmarks"
 		}
 		if version == "dev" && !strings.HasPrefix(title, "dev: ") {
 			title = "dev: " + title

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -15,7 +15,7 @@
                 <table border=0 id="layout">
                         <tr valign=top>
                                 <td width=200px id="nav">
-                                        <strong>Arran4</strong>'s bookmarks tool.<br>
+                                        <strong>gobookmarks</strong><br>
                                         <a href="/">Home</a><br>
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>


### PR DESCRIPTION
## Summary
- trim arran4 from the navigation label
- drop arran4 from the fallback title when none is provided

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685bf450e528832f8c1ff282509416ad