### PR TITLE
Implement paginated commit history

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -94,6 +94,14 @@ func main() {
 		NoFooter:             os.Getenv("GBM_NO_FOOTER") != "",
 		SessionKey:           os.Getenv("SESSION_KEY"),
 		ProviderOrder:        splitList(os.Getenv("PROVIDER_ORDER")),
+		CommitsPerPage: func() int {
+			if v := os.Getenv("COMMITS_PER_PAGE"); v != "" {
+				if i, err := strconv.Atoi(v); err == nil {
+					return i
+				}
+			}
+			return 0
+		}(),
 	}
 
 	configPath := DefaultConfigPath()
@@ -110,6 +118,7 @@ func main() {
 	var glServerFlag stringFlag
 	var faviconDirFlag stringFlag
 	var faviconSizeFlag stringFlag
+	var commitsPerPageFlag stringFlag
 	var localGitPathFlag stringFlag
 	var dbProviderFlag stringFlag
 	var dbConnFlag stringFlag
@@ -129,6 +138,7 @@ func main() {
 	flag.Var(&titleFlag, "title", "site title")
 	flag.Var(&faviconDirFlag, "favicon-cache-dir", "directory for cached favicons")
 	flag.Var(&faviconSizeFlag, "favicon-cache-size", "max size of favicon cache in bytes")
+	flag.Var(&commitsPerPageFlag, "commits-per-page", "commits per page")
 	flag.Var(&ghServerFlag, "github-server", "GitHub base URL")
 	flag.Var(&glServerFlag, "gitlab-server", "GitLab base URL")
 	flag.Var(&localGitPathFlag, "local-git-path", "directory for local git provider")
@@ -205,6 +215,11 @@ func main() {
 			cfg.FaviconCacheSize = i
 		}
 	}
+	if commitsPerPageFlag.set {
+		if i, err := strconv.Atoi(commitsPerPageFlag.value); err == nil {
+			cfg.CommitsPerPage = i
+		}
+	}
 	if glServerFlag.set {
 		cfg.GitlabServer = glServerFlag.value
 	}
@@ -248,6 +263,11 @@ func main() {
 		FaviconCacheSize = cfg.FaviconCacheSize
 	} else {
 		FaviconCacheSize = DefaultFaviconCacheSize
+	}
+	if cfg.CommitsPerPage != 0 {
+		CommitsPerPage = cfg.CommitsPerPage
+	} else {
+		CommitsPerPage = DefaultCommitsPerPage
 	}
 	if cfg.LocalGitPath != "" {
 		LocalGitPath = cfg.LocalGitPath

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	DBConnectionProvider string   `json:"db_connection_provider"`
 	DBConnectionString   string   `json:"db_connection_string"`
 	ProviderOrder        []string `json:"provider_order"`
+	CommitsPerPage       int      `json:"commits_per_page"`
 }
 
 // LoadConfigFile loads configuration from the given path.
@@ -128,6 +129,9 @@ func MergeConfig(dst *Config, src Config) {
 	}
 	if src.DBConnectionString != "" {
 		dst.DBConnectionString = src.DBConnectionString
+	}
+	if src.CommitsPerPage != 0 {
+		dst.CommitsPerPage = src.CommitsPerPage
 	}
 	if len(src.ProviderOrder) > 0 {
 		dst.ProviderOrder = append([]string(nil), src.ProviderOrder...)

--- a/data_test.go
+++ b/data_test.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"io"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -51,13 +52,21 @@ func testFuncMap() template.FuncMap {
 		"errorMsg":           func(s string) string { return s },
 		"ref":                func() string { return "refs/heads/main" },
 		"add1":               func(i int) int { return i + 1 },
-		"tab":                func() string { return "0" },
-		"tabName":            func() string { return "Main" },
-		"page":               func() string { return "" },
-		"useCssColumns":      func() bool { return false },
-		"showFooter":         func() bool { return true },
-		"showPages":          func() bool { return true },
-		"loggedIn":           func() (bool, error) { return true, nil },
+		"sub1": func(i int) int {
+			if i > 0 {
+				return i - 1
+			}
+			return 0
+		},
+		"atoi":          func(s string) int { i, _ := strconv.Atoi(s); return i },
+		"tab":           func() string { return "0" },
+		"tabName":       func() string { return "Main" },
+		"page":          func() string { return "" },
+		"historyRef":    func() string { return "refs/heads/main" },
+		"useCssColumns": func() bool { return false },
+		"showFooter":    func() bool { return true },
+		"showPages":     func() bool { return true },
+		"loggedIn":      func() (bool, error) { return true, nil },
 		"bookmarkTabs": func() ([]TabInfo, error) {
 			return []TabInfo{{Index: 0, Name: "", IndexName: "Main", Href: "/", LastPageSha: ""}}, nil
 		},
@@ -113,6 +122,8 @@ func testFuncMap() template.FuncMap {
 				CommitterDate:  time.Unix(0, 0),
 			}}, nil
 		},
+		"prevCommit": func() string { return "prev" },
+		"nextCommit": func() string { return "next" },
 	}
 }
 

--- a/provider.go
+++ b/provider.go
@@ -33,13 +33,18 @@ type Provider interface {
 	CurrentUser(ctx context.Context, token *oauth2.Token) (*User, error)
 	GetTags(ctx context.Context, user string, token *oauth2.Token) ([]*Tag, error)
 	GetBranches(ctx context.Context, user string, token *oauth2.Token) ([]*Branch, error)
-	GetCommits(ctx context.Context, user string, token *oauth2.Token) ([]*Commit, error)
+	GetCommits(ctx context.Context, user string, token *oauth2.Token, ref string, page, perPage int) ([]*Commit, error)
 	GetBookmarks(ctx context.Context, user, ref string, token *oauth2.Token) (string, string, error)
 	UpdateBookmarks(ctx context.Context, user string, token *oauth2.Token, sourceRef, branch, text, expectSHA string) error
 	CreateBookmarks(ctx context.Context, user string, token *oauth2.Token, branch, text string) error
 	CreateRepo(ctx context.Context, user string, token *oauth2.Token, name string) error
 	RepoExists(ctx context.Context, user string, token *oauth2.Token, name string) (bool, error)
 	DefaultServer() string
+}
+
+// AdjacentCommitProvider optionally provides methods to navigate commit history.
+type AdjacentCommitProvider interface {
+	AdjacentCommits(ctx context.Context, user string, token *oauth2.Token, ref, sha string) (string, string, error)
 }
 
 // PasswordHandler is implemented by providers that manage passwords.

--- a/provider_github.go
+++ b/provider_github.go
@@ -96,8 +96,9 @@ func (p GitHubProvider) GetBranches(ctx context.Context, user string, token *oau
 	return res, nil
 }
 
-func (p GitHubProvider) GetCommits(ctx context.Context, user string, token *oauth2.Token) ([]*Commit, error) {
-	cs, _, err := p.client(ctx, token).Repositories.ListCommits(ctx, user, RepoName, &github.CommitsListOptions{})
+func (p GitHubProvider) GetCommits(ctx context.Context, user string, token *oauth2.Token, ref string, page, perPage int) ([]*Commit, error) {
+	opts := &github.CommitsListOptions{SHA: ref, ListOptions: github.ListOptions{Page: page, PerPage: perPage}}
+	cs, _, err := p.client(ctx, token).Repositories.ListCommits(ctx, user, RepoName, opts)
 	if err != nil {
 		log.Printf("github GetCommits: %v", err)
 		return nil, fmt.Errorf("ListCommits: %w", err)

--- a/provider_gitlab.go
+++ b/provider_gitlab.go
@@ -117,13 +117,13 @@ func (GitLabProvider) GetBranches(ctx context.Context, user string, token *oauth
 	return res, nil
 }
 
-func (GitLabProvider) GetCommits(ctx context.Context, user string, token *oauth2.Token) ([]*Commit, error) {
+func (GitLabProvider) GetCommits(ctx context.Context, user string, token *oauth2.Token, ref string, page, perPage int) ([]*Commit, error) {
 	c, err := GitLabProvider{}.client(token)
 	if err != nil {
 		log.Printf("gitlab GetCommits client: %v", err)
 		return nil, err
 	}
-	cs, _, err := c.Commits.ListCommits(user+"/"+RepoName, &gitlab.ListCommitsOptions{})
+	cs, _, err := c.Commits.ListCommits(user+"/"+RepoName, &gitlab.ListCommitsOptions{RefName: &ref, ListOptions: gitlab.ListOptions{Page: page, PerPage: perPage}})
 	if err != nil {
 		if gitlabUnauthorized(err) {
 			return nil, ErrSignedOut

--- a/settings.go
+++ b/settings.go
@@ -24,9 +24,12 @@ var (
 
 	DBConnectionProvider string
 	DBConnectionString   string
+
+	CommitsPerPage int
 )
 
 const (
 	DefaultFaviconCacheSize   int64         = 20 * 1024 * 1024 // 20MB
 	DefaultFaviconCacheMaxAge time.Duration = 24 * time.Hour
+	DefaultCommitsPerPage     int           = 100
 )

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -20,6 +20,10 @@
                                         {{ if $.UserRef }}
                                                 <a href="/logout">Logout</a><br/>
                                                 <a href="/history">History</a><br/>
+                                                {{ if historyRef }}
+                                                    {{ $prev := prevCommit }}{{ if $prev }}<a href="/?ref={{ $prev }}&historyRef={{ historyRef }}{{ if tab }}&tab={{ tab }}{{ end }}">Back 1 commit</a><br/>{{ end }}
+                                                    {{ $next := nextCommit }}{{ if $next }}<a href="/?ref={{ $next }}&historyRef={{ historyRef }}{{ if tab }}&tab={{ tab }}{{ end }}">Forwards 1 commit</a><br/>{{ end }}
+                                                {{ end }}
                                                 <a id="toggle-edit" href="/?{{if $.EditMode}}{{if tab}}tab={{tab}}{{end}}{{else}}edit=1{{if tab}}&tab={{tab}}{{end}}{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
                                                 {{if $.EditMode}}<a href="/edit?edit=1{{if ref}}&ref={{ref}}{{end}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a><br/>{{end}}
                                                 <hr/>

--- a/templates/historyCommits.gohtml
+++ b/templates/historyCommits.gohtml
@@ -10,7 +10,7 @@
         <tbody>
             {{- range commits }}
                 <tr>
-                    <td><a href="/?ref={{ .SHA }}">{{ .SHA }}</a></td>
+                    <td><a href="/?ref={{ .SHA }}{{ if ref }}&historyRef={{ ref }}{{ end }}">{{ .SHA }}</a></td>
                     <td>{{ .Message }}</td>
                     <td>{{ .CommitterDate }}</td>
                     <td>{{ .CommitterName }} / {{ .CommitterEmail }}</td>
@@ -18,5 +18,10 @@
             {{- end }}
         </tbody>
     </table>
-    
+    <div class="pagination">
+        {{ $p := atoi (page) }}
+        {{ if gt $p 1 }}<a href="/history/commits?page={{ sub1 $p }}{{ if ref }}&ref={{ ref }}{{ end }}">Previous</a>{{ end }}
+        <a href="/history/commits?page={{ add1 $p }}{{ if ref }}&ref={{ ref }}{{ end }}">Next</a>
+    </div>
+
 {{ template "tail" $ }}


### PR DESCRIPTION
## Summary
- introduce `CommitsPerPage` config with default 100
- paginate commit history by ref (branch/tag)
- expose `historyRef`, `prevCommit`, and `nextCommit` helpers for templates
- add commit navigation to sidebar and keep ref when browsing history

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68630ab35270832f861b561ac1f6a774