### PR TITLE
Improve template error handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -21,3 +21,30 @@ var ErrUserExists = errors.New("user already exists")
 
 // ErrUserNotFound indicates that a user does not exist when attempting to set a password.
 var ErrUserNotFound = errors.New("user not found")
+
+// UserError wraps an error message intended for display to the user.
+// It satisfies the error interface so it can be returned like a normal error.
+// UserError describes an error that has a user facing message.
+// The wrapped error can be inspected using errors.As/Is.
+type UserError struct {
+	Msg string // message shown to the user
+	Err error  // underlying error
+}
+
+// Error implements the error interface by returning the underlying error
+// message so logs and comparisons use the wrapped error.
+func (e UserError) Error() string {
+	if e.Err == nil {
+		return e.Msg
+	}
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (e UserError) Unwrap() error { return e.Err }
+
+// NewUserError creates a UserError with the provided display message and
+// underlying cause.
+func NewUserError(msg string, err error) error {
+	return UserError{Msg: msg, Err: err}
+}

--- a/provider_sql.go
+++ b/provider_sql.go
@@ -38,19 +38,22 @@ func (SQLProvider) CurrentUser(ctx context.Context, token *oauth2.Token) (*User,
 
 func openDB() (*sql.DB, error) {
 	if DBConnectionProvider == "" {
-		return nil, errors.New("db provider not configured")
+		return nil, NewUserError("Database error", errors.New("db provider not configured"))
 	}
+
 	db, err := sql.Open(DBConnectionProvider, DBConnectionString)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open db: %v", err)
+		return nil, NewUserError("Database error", fmt.Errorf("failed to open db: %w", err))
 	}
+
 	if err := db.Ping(); err != nil {
 		db.Close()
-		return nil, err
+		return nil, NewUserError("Database error", err)
 	}
+
 	if err := ensureSQLSchema(db); err != nil {
 		db.Close()
-		return nil, fmt.Errorf("failed to ensure schema: %v", err)
+		return nil, NewUserError("Database error", fmt.Errorf("failed to ensure schema: %w", err))
 	}
 	return db, nil
 }


### PR DESCRIPTION
## Summary
- add UserError struct for easier error display
- simplify runTemplate logic using never-nest style
- add user-facing error logic in handlers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68670c23e7fc832fbe8f4ca7b593c86a