### PR TITLE
Add page/tab keyboard shortcuts and filter search

### DIFF
--- a/main.css
+++ b/main.css
@@ -239,3 +239,27 @@ body:not(.edit-mode) .moveIcon {
 body:not(.edit-mode) .move-handle {
     display: none;
 }
+
+#search-overlay {
+    position: fixed;
+    top: 10%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #FFFBF0;
+    color: #800000;
+    border: 1px solid #800000;
+    padding: 1em;
+    z-index: 1000;
+    display: none;
+}
+
+#search-results {
+    max-height: 50vh;
+    overflow-y: auto;
+    margin-top: 0.5em;
+}
+
+#search-results div.selected {
+    background: #800000;
+    color: #FFFBF0;
+}

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -15,9 +15,15 @@
                                </i>
                        </div>
 </footer>
-                {{ end }}
-                <script>
-                document.addEventListener('DOMContentLoaded', function () {
+                 {{ end }}
+
+                 <div id="search-overlay">
+                     <input id="search-input" type="text" placeholder="Search..." />
+                     <div id="search-results"></div>
+                 </div>
+
+                 <script>
+                 document.addEventListener('DOMContentLoaded', function () {
                     var toggleEdit = document.getElementById('toggle-edit');
 
                     function currentPage() {
@@ -49,8 +55,92 @@
                         });
                     }
 
-                    attach(toggleEdit);
-                });
+                     attach(toggleEdit);
+
+                     function switchPage(delta) {
+                         var pages = document.querySelectorAll('#page-list li a');
+                         if (!pages.length) return;
+                         var idx = currentPage();
+                         if (idx < 0) idx = 0;
+                         idx = Math.max(0, Math.min(pages.length - 1, idx + delta));
+                         window.location.href = pages[idx].href;
+                     }
+
+                     function switchTab(delta) {
+                         var tabs = document.querySelectorAll('#tab-list li a');
+                         if (!tabs.length) return;
+                         var current = document.body.dataset.tab || '';
+                         var idx = Array.from(tabs).findIndex(function(a){
+                             return a.href.includes('tab=' + encodeURIComponent(current));
+                         });
+                         if (idx < 0) idx = 0;
+                         idx = Math.max(0, Math.min(tabs.length - 1, idx + delta));
+                         window.location.href = tabs[idx].href;
+                     }
+
+                     var overlay = document.getElementById('search-overlay');
+                     var input = document.getElementById('search-input');
+                     var resultsEl = document.getElementById('search-results');
+                     var results = [];
+                     var sel = 0;
+
+                     function renderResults() {
+                         resultsEl.innerHTML = '';
+                         results.forEach(function(a, i){
+                             var div = document.createElement('div');
+                             div.textContent = a.textContent;
+                             if (i === sel) div.classList.add('selected');
+                             resultsEl.appendChild(div);
+                         });
+                     }
+
+                     function updateResults() {
+                         var q = input.value.toLowerCase();
+                         results = [];
+                         if (q) {
+                             document.querySelectorAll('.bookmarkPage a').forEach(function(a){
+                                 if (a.textContent.toLowerCase().includes(q)) {
+                                     results.push(a);
+                                 }
+                             });
+                         }
+                         sel = 0;
+                         renderResults();
+                     }
+
+                     input.addEventListener('input', updateResults);
+
+                     function openSearch() {
+                         overlay.style.display = 'block';
+                         input.value = '';
+                         updateResults();
+                         input.focus();
+                     }
+
+                     function closeSearch() {
+                         overlay.style.display = 'none';
+                     }
+
+                     document.addEventListener('keydown', function(e){
+                         if (overlay.style.display === 'block') {
+                             if (e.key === 'Escape') { closeSearch(); }
+                             else if (e.key === 'ArrowDown') { if (sel < results.length-1) { sel++; renderResults(); } e.preventDefault(); }
+                             else if (e.key === 'ArrowUp') { if (sel > 0) { sel--; renderResults(); } e.preventDefault(); }
+                             else if (e.key === 'Enter') { if (results[sel]) { window.location.href = results[sel].href; closeSearch(); } }
+                             return;
+                         }
+
+                         if (e.ctrlKey && e.altKey && e.shiftKey) {
+                             if (e.key === 'ArrowDown') { e.preventDefault(); switchPage(1); }
+                             else if (e.key === 'ArrowUp') { e.preventDefault(); switchPage(-1); }
+                             else if (e.key === 'ArrowRight') { e.preventDefault(); switchTab(1); }
+                             else if (e.key === 'ArrowLeft') { e.preventDefault(); switchTab(-1); }
+                             else if (e.key.toLowerCase() === 'f') { e.preventDefault(); openSearch(); }
+                         }
+                     });
+
+                     window.addEventListener('blur', function(){ closeSearch(); });
+                 });
                 </script>
                  </body>
 </html>


### PR DESCRIPTION
## Summary
- add a search overlay with results list
- implement keyboard shortcuts to cycle pages and tabs
- support searching links and selecting via keyboard
- style the search overlay

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877118bc0a4832fbda90a64957b4fba