### PR TITLE
Fix empty first page when using Page after Tab

### DIFF
--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -332,8 +332,12 @@ func ParseBookmarks(bookmarks string) BookmarkList {
 			}
 			flushCategory()
 			ensureTab()
-			currentPage = &BookmarkPage{Name: rest, Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}}
-			currentTab.AddPage(currentPage)
+			if currentPage != nil && currentPage.IsEmpty() && len(currentTab.Pages) == 1 {
+				currentPage.Name = rest
+			} else {
+				currentPage = &BookmarkPage{Name: rest, Blocks: []*BookmarkBlock{{Columns: []*BookmarkColumn{{}}}}}
+				currentTab.AddPage(currentPage)
+			}
 			continue
 		}
 		if line == "--" {


### PR DESCRIPTION
## Summary
- avoid creating blank first pages when the first directive in a tab is `Page`
- test parsing a tab with an explicitly named first page
- validate page names for pages defined without a colon
- add a helper to create named pages in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6877210b0440832f8623a8e825587c61