### PR TITLE
Add search filter and keyboard shortcuts

### DIFF
--- a/main.css
+++ b/main.css
@@ -239,3 +239,15 @@ body:not(.edit-mode) .moveIcon {
 body:not(.edit-mode) .move-handle {
     display: none;
 }
+
+/* Search box styles */
+#search-box {
+    width: 90%;
+    margin-top: 0.5em;
+}
+.search-hidden {
+    display: none;
+}
+.search-selected {
+    background-color: #ffe0e0;
+}

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -26,6 +26,7 @@
                                                 {{ end }}
                                                 <a id="toggle-edit" href="/?{{if $.EditMode}}{{if tab}}tab={{tab}}{{end}}{{else}}edit=1{{if tab}}&tab={{tab}}{{end}}{{end}}">{{if $.EditMode}}Stop Edit{{else}}Edit{{end}}</a><br/>
                                                 {{if $.EditMode}}<a href="/edit?edit=1{{if ref}}&ref={{ref}}{{end}}{{if tab}}&tab={{tab}}{{end}}">Edit All</a><br/>{{end}}
+                                                <input id="search-box" type="text" placeholder="Search" style="width: 100%;" autocomplete="off" spellcheck="false" /><br/>
                                                 <hr/>
                                                 <b>Tabs</b>
                                                 <ul id="tab-list" style="list-style-type:none;padding-left:0;">

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -50,6 +50,160 @@
                     }
 
                     attach(toggleEdit);
+
+                    var searchBox = document.getElementById('search-box');
+                    var searchResults = [];
+                    var selectedIndex = 0;
+
+                    function clearSearch() {
+                        document.querySelectorAll('.search-hidden').forEach(function(el){
+                            el.classList.remove('search-hidden');
+                        });
+                        document.querySelectorAll('.search-selected').forEach(function(el){
+                            el.classList.remove('search-selected');
+                        });
+                        searchResults = [];
+                        selectedIndex = 0;
+                    }
+
+                    function updateSearch() {
+                        clearSearch();
+                        if (!searchBox) return;
+                        var q = searchBox.value.trim().toLowerCase();
+                        if (!q) return;
+                        var items = document.querySelectorAll('.bookmark-entries li');
+                        items.forEach(function(li) {
+                            var a = li.querySelector('a[target="_blank"]');
+                            if (!a) return;
+                            var text = a.textContent.toLowerCase();
+                            var url = a.getAttribute('href').toLowerCase();
+                            if (text.indexOf(q) !== -1 || url.indexOf(q) !== -1) {
+                                searchResults.push(li);
+                            } else {
+                                li.classList.add('search-hidden');
+                            }
+                        });
+                        if (searchResults.length > 0) {
+                            searchResults[0].classList.add('search-selected');
+                            searchResults[0].scrollIntoView({block: 'nearest'});
+                        }
+                    }
+
+                    function moveSelection(delta) {
+                        if (searchResults.length === 0) return;
+                        searchResults[selectedIndex].classList.remove('search-selected');
+                        selectedIndex = (selectedIndex + delta + searchResults.length) % searchResults.length;
+                        searchResults[selectedIndex].classList.add('search-selected');
+                        searchResults[selectedIndex].scrollIntoView({block: 'nearest'});
+                    }
+
+                    function moveSelectionHorizontal(dir) {
+                        if (searchResults.length === 0) return;
+                        var cur = searchResults[selectedIndex];
+                        var r0 = cur.getBoundingClientRect();
+                        var midY = (r0.top + r0.bottom) / 2;
+                        var best = -1;
+                        var bestDist = Infinity;
+                        searchResults.forEach(function(li, idx){
+                            if (idx === selectedIndex) return;
+                            var r = li.getBoundingClientRect();
+                            var withinY = Math.abs(((r.top + r.bottom)/2) - midY);
+                            if (dir < 0 && r.right <= r0.left) {
+                                var dist = (r0.left - r.right) * (r0.left - r.right) + withinY * withinY;
+                                if (dist < bestDist) { bestDist = dist; best = idx; }
+                            } else if (dir > 0 && r.left >= r0.right) {
+                                var dist = (r.left - r0.right) * (r.left - r0.right) + withinY * withinY;
+                                if (dist < bestDist) { bestDist = dist; best = idx; }
+                            }
+                        });
+                        if (best >= 0) {
+                            searchResults[selectedIndex].classList.remove('search-selected');
+                            selectedIndex = best;
+                            searchResults[selectedIndex].classList.add('search-selected');
+                            searchResults[selectedIndex].scrollIntoView({block: 'nearest'});
+                        }
+                    }
+
+                    if (searchBox) {
+                        searchBox.addEventListener('input', updateSearch);
+                        searchBox.addEventListener('keydown', function(e) {
+                            if (e.key === 'ArrowDown') {
+                                moveSelection(1);
+                                e.preventDefault();
+                            } else if (e.key === 'ArrowUp') {
+                                moveSelection(-1);
+                                e.preventDefault();
+                            } else if (e.key === 'Enter') {
+                                if (searchResults.length > 0) {
+                                    var link = searchResults[selectedIndex].querySelector('a');
+                                    if (link) {
+                                        window.location.href = link.href;
+                                    }
+                                }
+                            } else if (e.key === 'Escape') {
+                                searchBox.blur();
+                                e.preventDefault();
+                            }
+                        });
+                    }
+
+                    function changePage(delta) {
+                        var pages = document.querySelectorAll('.bookmarkPage[id^="page"]');
+                        if (!pages.length) return;
+                        var cur = currentPage();
+                        if (cur < 0) cur = 0;
+                        var next = (cur + delta + pages.length) % pages.length;
+                        var id = pages[next].id;
+                        location.hash = '#' + id;
+                        pages[next].scrollIntoView();
+                    }
+
+                    function changeTab(delta) {
+                        var tabs = document.querySelectorAll('#tab-list a');
+                        if (!tabs.length) return;
+                        var params = new URLSearchParams(window.location.search);
+                        var idx = parseInt(params.get('tab') || '0');
+                        if (isNaN(idx)) idx = 0;
+                        var next = (idx + delta + tabs.length) % tabs.length;
+                        window.location.href = tabs[next].href;
+                    }
+
+                    document.addEventListener('keydown', function(e) {
+                        var active = document.activeElement;
+                        var inInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable);
+
+                        if (e.altKey && !e.ctrlKey && !e.metaKey) {
+                            if (e.key === ']') { changePage(1); e.preventDefault(); return; }
+                            if (e.key === '[') { changePage(-1); e.preventDefault(); return; }
+                            if (e.key === '}') { changeTab(1); e.preventDefault(); return; }
+                            if (e.key === '{') { changeTab(-1); e.preventDefault(); return; }
+                            if (e.key.toLowerCase() === 'k') { if (searchBox) { searchBox.focus(); searchBox.select(); } e.preventDefault(); return; }
+                        }
+
+                        if (!inInput) {
+                            if (e.key === 'ArrowDown') { moveSelection(1); e.preventDefault(); }
+                            else if (e.key === 'ArrowUp') { moveSelection(-1); e.preventDefault(); }
+                            else if (e.key === 'ArrowRight') { moveSelectionHorizontal(1); e.preventDefault(); }
+                            else if (e.key === 'ArrowLeft') { moveSelectionHorizontal(-1); e.preventDefault(); }
+                            else if (e.key === '?') {
+                                alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows navigate results\nEsc - exit search (press twice)');
+                                e.preventDefault();
+                            } else if (e.key === 'Escape') {
+                                if (searchBox && searchBox.value !== '') {
+                                    searchBox.value = '';
+                                    clearSearch();
+                                } else if (searchBox) {
+                                    searchBox.blur();
+                                }
+                                e.preventDefault();
+                            } else if (e.key === 'Enter') {
+                                if (searchResults.length > 0) {
+                                    var link = searchResults[selectedIndex].querySelector('a');
+                                    if (link) { window.location.href = link.href; }
+                                }
+                            }
+                        }
+                    });
                 });
                 </script>
                  </body>

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -85,7 +85,13 @@
                         });
                         if (searchResults.length > 0) {
                             searchResults[0].classList.add('search-selected');
-                            searchResults[0].scrollIntoView({block: 'nearest'});
+                            var firstPage = searchResults[0].closest('.bookmarkPage');
+                            if (firstPage) {
+                                location.hash = '#' + firstPage.id;
+                                firstPage.scrollIntoView({block: 'center'});
+                            } else {
+                                searchResults[0].scrollIntoView({block: 'nearest'});
+                            }
                         }
                     }
 

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -54,8 +54,25 @@
                     var searchBox = document.getElementById('search-box');
                     var searchResults = [];
                     var selectedIndex = 0;
+                    var initialHash = '';
+                    var initialPage = -1;
 
-                    function clearSearch() {
+                    function restoreInitial() {
+                        if (initialHash !== '') {
+                            var pages = document.querySelectorAll('.bookmarkPage[id^="page"]');
+                            if (initialPage >= 0 && pages.length > initialPage) {
+                                var p = pages[initialPage];
+                                location.hash = '#' + p.id;
+                                p.scrollIntoView({block: 'center'});
+                            } else if (initialHash) {
+                                location.hash = initialHash;
+                            }
+                        }
+                        initialHash = '';
+                        initialPage = -1;
+                    }
+
+                    function resetResults() {
                         document.querySelectorAll('.search-hidden').forEach(function(el){
                             el.classList.remove('search-hidden');
                         });
@@ -66,11 +83,20 @@
                         selectedIndex = 0;
                     }
 
+                    function clearSearch() {
+                        resetResults();
+                        restoreInitial();
+                    }
+
                     function updateSearch() {
-                        clearSearch();
+                        resetResults();
                         if (!searchBox) return;
                         var q = searchBox.value.trim().toLowerCase();
                         if (!q) return;
+                        if (initialHash === '') {
+                            initialHash = location.hash;
+                            initialPage = currentPage();
+                        }
                         var items = document.querySelectorAll('.bookmark-entries li');
                         items.forEach(function(li) {
                             var a = li.querySelector('a[target="_blank"]');
@@ -171,7 +197,9 @@
                                 if (searchResults.length > 0) {
                                     var link = searchResults[selectedIndex].querySelector('a');
                                     if (link) {
-                                        if (link.target && link.target === '_blank') {
+                                        if (e.ctrlKey || e.metaKey) {
+                                            window.open(link.href, '_blank', 'noopener');
+                                        } else if (link.target && link.target === '_blank') {
                                             window.open(link.href, '_blank');
                                         } else {
                                             window.location.href = link.href;
@@ -229,7 +257,7 @@
                             else if (e.key === 'ArrowRight') { moveSelectionHorizontal(1); e.preventDefault(); }
                             else if (e.key === 'ArrowLeft') { moveSelectionHorizontal(-1); e.preventDefault(); }
                             else if (e.key === '?') {
-                                alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows navigate results\nEsc - exit search (press twice)');
+                                alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows move selection\nEnter - open\nCtrl+Enter - open in background\nEsc twice - clear search and restore view');
                                 e.preventDefault();
                             } else if (e.key === 'Escape') {
                                 if (searchBox && searchBox.value !== '') {
@@ -243,7 +271,9 @@
                                 if (searchResults.length > 0) {
                                     var link = searchResults[selectedIndex].querySelector('a');
                                     if (link) {
-                                        if (link.target && link.target === '_blank') {
+                                        if (e.ctrlKey || e.metaKey) {
+                                            window.open(link.href, '_blank', 'noopener');
+                                        } else if (link.target && link.target === '_blank') {
                                             window.open(link.href, '_blank');
                                         } else {
                                             window.location.href = link.href;

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -93,10 +93,12 @@
                                 searchResults[0].scrollIntoView({block: 'nearest'});
                             }
                         }
+                        searchBox.focus();
                     }
 
                     function moveSelection(delta) {
                         if (searchResults.length === 0) return;
+                        var hadFocus = document.activeElement === searchBox;
                         var cur = searchResults[selectedIndex];
                         cur.classList.remove('search-selected');
                         selectedIndex = (selectedIndex + delta + searchResults.length) % searchResults.length;
@@ -110,10 +112,12 @@
                         } else {
                             nextEl.scrollIntoView({block: 'nearest'});
                         }
+                        if (hadFocus) searchBox.focus();
                     }
 
                     function moveSelectionHorizontal(dir) {
                         if (searchResults.length === 0) return;
+                        var hadFocus = document.activeElement === searchBox;
                         var cur = searchResults[selectedIndex];
                         var r0 = cur.getBoundingClientRect();
                         var midY = (r0.top + r0.bottom) / 2;
@@ -145,6 +149,7 @@
                                 nextEl.scrollIntoView({block: 'nearest'});
                             }
                         }
+                        if (hadFocus) searchBox.focus();
                     }
 
                     if (searchBox) {
@@ -156,13 +161,25 @@
                             } else if (e.key === 'ArrowUp') {
                                 moveSelection(-1);
                                 e.preventDefault();
+                            } else if (e.key === 'ArrowRight') {
+                                moveSelectionHorizontal(1);
+                                e.preventDefault();
+                            } else if (e.key === 'ArrowLeft') {
+                                moveSelectionHorizontal(-1);
+                                e.preventDefault();
                             } else if (e.key === 'Enter') {
                                 if (searchResults.length > 0) {
                                     var link = searchResults[selectedIndex].querySelector('a');
                                     if (link) {
-                                        window.location.href = link.href;
+                                        if (link.target && link.target === '_blank') {
+                                            window.open(link.href, '_blank');
+                                        } else {
+                                            window.location.href = link.href;
+                                        }
+                                        searchBox.focus();
                                     }
                                 }
+                                e.preventDefault();
                             } else if (e.key === 'Escape') {
                                 searchBox.blur();
                                 e.preventDefault();
@@ -174,12 +191,14 @@
                     function changePage(delta) {
                         var pages = document.querySelectorAll('.bookmarkPage[id^="page"]');
                         if (!pages.length) return;
+                        var hadFocus = document.activeElement === searchBox;
                         var cur = currentPage();
                         if (cur < 0) cur = 0;
                         var next = (cur + delta + pages.length) % pages.length;
                         var id = pages[next].id;
                         location.hash = '#' + id;
                         pages[next].scrollIntoView();
+                        if (hadFocus) searchBox.focus();
                     }
 
                     function changeTab(delta) {
@@ -223,7 +242,14 @@
                             } else if (e.key === 'Enter') {
                                 if (searchResults.length > 0) {
                                     var link = searchResults[selectedIndex].querySelector('a');
-                                    if (link) { window.location.href = link.href; }
+                                    if (link) {
+                                        if (link.target && link.target === '_blank') {
+                                            window.open(link.href, '_blank');
+                                        } else {
+                                            window.location.href = link.href;
+                                        }
+                                        if (searchBox) searchBox.focus();
+                                    }
                                 }
                             }
                         }

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -91,10 +91,19 @@
 
                     function moveSelection(delta) {
                         if (searchResults.length === 0) return;
-                        searchResults[selectedIndex].classList.remove('search-selected');
+                        var cur = searchResults[selectedIndex];
+                        cur.classList.remove('search-selected');
                         selectedIndex = (selectedIndex + delta + searchResults.length) % searchResults.length;
-                        searchResults[selectedIndex].classList.add('search-selected');
-                        searchResults[selectedIndex].scrollIntoView({block: 'nearest'});
+                        var nextEl = searchResults[selectedIndex];
+                        nextEl.classList.add('search-selected');
+                        var curPage = cur.closest('.bookmarkPage');
+                        var newPage = nextEl.closest('.bookmarkPage');
+                        if (newPage && curPage !== newPage) {
+                            location.hash = '#' + newPage.id;
+                            newPage.scrollIntoView({block: 'center'});
+                        } else {
+                            nextEl.scrollIntoView({block: 'nearest'});
+                        }
                     }
 
                     function moveSelectionHorizontal(dir) {
@@ -117,10 +126,18 @@
                             }
                         });
                         if (best >= 0) {
+                            var curPage = cur.closest('.bookmarkPage');
                             searchResults[selectedIndex].classList.remove('search-selected');
                             selectedIndex = best;
-                            searchResults[selectedIndex].classList.add('search-selected');
-                            searchResults[selectedIndex].scrollIntoView({block: 'nearest'});
+                            var nextEl = searchResults[selectedIndex];
+                            nextEl.classList.add('search-selected');
+                            var newPage = nextEl.closest('.bookmarkPage');
+                            if (newPage && curPage !== newPage) {
+                                location.hash = '#' + newPage.id;
+                                newPage.scrollIntoView({block: 'center'});
+                            } else {
+                                nextEl.scrollIntoView({block: 'nearest'});
+                            }
                         }
                     }
 
@@ -143,6 +160,7 @@
                             } else if (e.key === 'Escape') {
                                 searchBox.blur();
                                 e.preventDefault();
+                                e.stopPropagation();
                             }
                         });
                     }


### PR DESCRIPTION
## Summary
- add a search box in the nav and supporting styles
- implement search filtering with keyboard navigation
- add keyboard shortcuts for paging and tab switching using `Alt` plus brackets
- fix escape behavior to blur first and clear on second press

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6877118bc0a4832fbda90a64957b4fba