### PR TITLE
Add configurable CSP middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,8 @@ Configuration values can be supplied as environment variables, via a JSON config
 | `DB_CONNECTION_PROVIDER` | SQL driver name for the SQL provider. `mysql` or `sqlite`                                                                                                                                                                                    |
 | `DB_CONNECTION_STRING` | Connection string for the SQL provider. File path for `sqlite` or `user:pass@/database?multiStatements=true` See https://github.com/go-sql-driver/mysql                                                                                      |
 | `GBM_NO_FOOTER` | Hide the footer on pages.                                                                                                                                                                                                                    |
-| `SESSION_KEY` | Secret used to sign session cookies. If unset the program reads or creates `session.key` under `$XDG_STATE_HOME/gobookmarks`, `$HOME/.local/state/gobookmarks` or `/var/lib/gobookmarks`.                                                    |
+| `SESSION_KEY` | Secret used to sign session cookies. If unset the program reads or creates `session.key` under `$XDG_STATE_HOME/gobookmarks`, `$HOME/.local/state/gobookmarks` or `/var/lib/gobookmarks`. |
+| `CONTENT_SECURITY_POLICY` | Value for the `Content-Security-Policy` header applied to responses. Defaults to `default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';` |
 | `PROVIDER_ORDER` | Comma-separated list controlling the order login options are shown. Unrecognized names are ignored. Defaults to alphabetical order. |
 | `GOBM_ENV_FILE` | Path to a file of `KEY=VALUE` pairs loaded before the environment. Defaults to `/etc/gobookmarks/gobookmarks.env`.                                                                                                                           |
 | `GOBM_CONFIG_FILE` | Path to the JSON config file. If unset the program uses `$XDG_CONFIG_HOME/gobookmarks/config.json` or `$HOME/.config/gobookmarks/config.json` for normal users and `/etc/gobookmarks/config.json` when installed system‑wide or run as root. |
@@ -264,6 +265,7 @@ The `--dev-mode` flag or `GBM_DEV_MODE` environment variable toggles the develop
 Use `--github-server` or `GITHUB_SERVER` to override the GitHub base URL and `--gitlab-server` or `GITLAB_SERVER` for GitLab.
 Use `--no-footer` or `GBM_NO_FOOTER` to hide the footer on pages.
 Use `--provider-order` or `PROVIDER_ORDER` to customize the login button order.
+Set `CONTENT_SECURITY_POLICY` to override the default Content Security Policy if you need a stricter configuration.
 
 Running `gobookmarks --version` will print the version information along with the list of compiled-in providers.
 When no OAuth2 credentials are configured the login buttons are hidden. Visit `/status` to see which providers are available.

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -298,6 +298,10 @@ func main() {
 	if cfg.DBConnectionString != "" {
 		DBConnectionString = cfg.DBConnectionString
 	}
+	ContentSecurityPolicy = os.Getenv(ContentSecurityPolicyEnv)
+	if ContentSecurityPolicy == "" {
+		ContentSecurityPolicy = DefaultContentSecurityPolicy
+	}
 	githubID := cfg.GithubClientID
 	githubSecret := cfg.GithubSecret
 	gitlabID := cfg.GitlabClientID
@@ -327,6 +331,7 @@ func main() {
 
 	r.Use(UserAdderMiddleware)
 	r.Use(CoreAdderMiddleware)
+	r.Use(SecurityHeadersMiddleware)
 
 	r.HandleFunc("/main.css", func(writer http.ResponseWriter, request *http.Request) {
 		_, _ = writer.Write(GetMainCSSData())

--- a/security.go
+++ b/security.go
@@ -1,0 +1,17 @@
+package gobookmarks
+
+import "net/http"
+
+const ContentSecurityPolicyEnv = "CONTENT_SECURITY_POLICY"
+
+// SecurityHeadersMiddleware sets common security headers such as Content-Security-Policy.
+func SecurityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		policy := ContentSecurityPolicy
+		if policy == "" {
+			policy = DefaultContentSecurityPolicy
+		}
+		w.Header().Set("Content-Security-Policy", policy)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/security_test.go
+++ b/security_test.go
@@ -1,0 +1,18 @@
+package gobookmarks
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeadersMiddleware(t *testing.T) {
+	ContentSecurityPolicy = "img-src example.com"
+	handler := SecurityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if got := w.Result().Header.Get("Content-Security-Policy"); got != ContentSecurityPolicy {
+		t.Fatalf("expected %q got %q", ContentSecurityPolicy, got)
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -27,10 +27,16 @@ var (
 	DBConnectionString   string
 
 	CommitsPerPage int
+
+	// ContentSecurityPolicy is the value of the CSP header sent on responses.
+	ContentSecurityPolicy string
 )
 
 const (
 	DefaultFaviconCacheSize   int64         = 20 * 1024 * 1024 // 20MB
 	DefaultFaviconCacheMaxAge time.Duration = 24 * time.Hour
 	DefaultCommitsPerPage     int           = 100
+
+	// DefaultContentSecurityPolicy is applied when no policy is configured.
+	DefaultContentSecurityPolicy string = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'"
 )


### PR DESCRIPTION
## Summary
- add `SecurityHeadersMiddleware` that injects a Content-Security-Policy header
- expose `ContentSecurityPolicy` and default value via settings
- configure CSP from `CONTENT_SECURITY_POLICY` environment variable
- wire the middleware in `main.go`
- document the new option in `README.md`
- add a small test for the middleware

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687767c57e28832fbbb1162c687b1d34