### PR TITLE
Add search widget support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,10 @@ You can quickly search for any link on the same Tab you're on. (Tabs contain pag
 
 There is keyboard navigation, see keyboard shortcuts for details.
 
+Selecting the entry from quick search focuses its input field. Press **Enter** inside the widget to open the search in a new tab, **Shift+Enter** for a background tab and hold **Alt** to keep the entered text.
+
 [![media/simplescreenrecorder-2025-07-16_16.23.20.gif](media/simplescreenrecorder-2025-07-16_16.23.20.gif)](media/simplescreenrecorder-2025-07-16_16.23.20.gif)
+
 
 ### Search Widgets
 
@@ -211,10 +214,6 @@ Use a link starting with the `search:` scheme followed by a URL containing
 ```
 search:https://www.google.com/search?q=$query
 ```
-
-Selecting the entry from quick search focuses its input field. Press **Enter**
-inside the widget to open the search in a new tab, **Shift+Enter** for a
-background tab and hold **Alt** to keep the entered text.
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -226,8 +226,9 @@ quicker:
 * While the search box is focused, **Up/Down** or **Left/Right** arrows move
   between filtered results. Press **Enter** to open the selected link or
   **Ctrl+Enter**/**Meta+Enter** to open it in a background tab.
-* Pressing **Esc** once exits the search field. Pressing **Esc** again clears
-  the search and restores the previous view.
+* Pressing **Esc** inside the search field removes focus. Pressing **Esc**
+  again clears the search and restores the previous view. Search widgets use the
+  same pattern, with a third **Esc** press clearing all widget text.
 * Press **?** anywhere (outside of a text field) to see these shortcuts in a
   small help dialog.
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,19 @@ You can quickly search for any link on the same Tab you're on. (Tabs contain pag
 
 There is keyboard navigation, see keyboard shortcuts for details.
 
+### Search Widgets
+
+Use a link starting with the `search:` scheme followed by a URL containing
+`$query`, for example:
+
+```
+search:https://www.google.com/search?q=$query
+```
+
+Selecting the entry from quick search focuses its input field. Press **Enter**
+inside the widget to open the search in a new tab, **Shift+Enter** for a
+background tab and hold **Alt** to keep the entered text.
+
 [![media/simplescreenrecorder-2025-07-16_16.23.20.gif](media/simplescreenrecorder-2025-07-16_16.23.20.gif)](media/simplescreenrecorder-2025-07-16_16.23.20.gif)
 
 ## Keyboard Shortcuts

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ You can quickly search for any link on the same Tab you're on. (Tabs contain pag
 
 There is keyboard navigation, see keyboard shortcuts for details.
 
+[![media/simplescreenrecorder-2025-07-16_16.23.20.gif](media/simplescreenrecorder-2025-07-16_16.23.20.gif)](media/simplescreenrecorder-2025-07-16_16.23.20.gif)
+
 ### Search Widgets
 
 Use a link starting with the `search:` scheme followed by a URL containing
@@ -213,8 +215,6 @@ search:https://www.google.com/search?q=$query
 Selecting the entry from quick search focuses its input field. Press **Enter**
 inside the widget to open the search in a new tab, **Shift+Enter** for a
 background tab and hold **Alt** to keep the entered text.
-
-[![media/simplescreenrecorder-2025-07-16_16.23.20.gif](media/simplescreenrecorder-2025-07-16_16.23.20.gif)](media/simplescreenrecorder-2025-07-16_16.23.20.gif)
 
 ## Keyboard Shortcuts
 

--- a/data_test.go
+++ b/data_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -123,8 +124,10 @@ func testFuncMap() template.FuncMap {
 				CommitterDate:  time.Unix(0, 0),
 			}}, nil
 		},
-		"prevCommit": func() string { return "prev" },
-		"nextCommit": func() string { return "next" },
+		"prevCommit":  func() string { return "prev" },
+		"nextCommit":  func() string { return "next" },
+		"isSearchURL": func(string) bool { return false },
+		"searchURL":   func(u string) string { return strings.TrimPrefix(u, "search:") },
 	}
 }
 

--- a/funcs.go
+++ b/funcs.go
@@ -414,6 +414,12 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			}
 			return next
 		},
+		"isSearchURL": func(u string) bool {
+			return strings.HasPrefix(u, "search:")
+		},
+		"searchURL": func(u string) string {
+			return strings.TrimPrefix(u, "search:")
+		},
 	}
 }
 

--- a/main.css
+++ b/main.css
@@ -251,3 +251,8 @@ body:not(.edit-mode) .move-handle {
 .search-selected {
     background-color: #ffe0e0;
 }
+
+input.search-widget {
+    width: 80%;
+    margin-left: 0.2em;
+}

--- a/templates/mainPage.gohtml
+++ b/templates/mainPage.gohtml
@@ -23,8 +23,12 @@
                                 {{- range $j, $e := .Entries }}
                                     <li>
                                         <span class="move-handle">&#9776;</span>
-                                        <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
+                                        <img src="/proxy/favicon?url={{ if isSearchURL .Url }}{{ searchURL .Url }}{{ else }}{{ .Url }}{{ end }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
+                                        {{- if isSearchURL .Url }}
+                                        <input type="text" class="search-widget" data-search-url="{{ searchURL .Url }}" placeholder="{{ .DisplayName }}" />
+                                        {{- else }}
                                         <a href="{{ .Url }}" target="_blank">{{ .DisplayName }}</a>
+                                        {{- end }}
                                     </li>
                                 {{- end }}
                             </ul>
@@ -49,8 +53,12 @@
                                   {{- range $j, $e := .Entries }}
                                       <li>
                                           <span class="move-handle">&#9776;</span>
-                                          <img src="/proxy/favicon?url={{ .Url }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
+                                          <img src="/proxy/favicon?url={{ if isSearchURL .Url }}{{ searchURL .Url }}{{ else }}{{ .Url }}{{ end }}" alt="•" style="width: 1em; max-height: 1em; font-weight: bolder; font-family: -moz-bullet-font;" />
+                                          {{- if isSearchURL .Url }}
+                                          <input type="text" class="search-widget" data-search-url="{{ searchURL .Url }}" placeholder="{{ .DisplayName }}" />
+                                          {{- else }}
                                           <a href="{{ .Url }}" target="_blank">{{ .DisplayName }}</a>
+                                          {{- end }}
                                       </li>
                                   {{- end }}
                                 </ul>

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -57,7 +57,6 @@
                     var initialHash = '';
                     var initialPage = -1;
                     var lastSearchWidget = null;
-                    var widgetEscState = 'idle';
 
                     function restoreInitial() {
                         if (initialHash !== '') {
@@ -237,7 +236,6 @@
             document.querySelectorAll('input.search-widget').forEach(function(inp){
                 inp.addEventListener('focus', function(){
                     lastSearchWidget = inp;
-                    widgetEscState = 'idle';
                 });
                 inp.addEventListener('keydown', function(e){
                     if (e.key === 'Enter') {
@@ -255,12 +253,9 @@
                         e.preventDefault();
                     } else if (e.key === 'Escape') {
                         lastSearchWidget = inp;
-                        widgetEscState = 'clear-one';
                         inp.blur();
                         e.preventDefault();
                         e.stopPropagation();
-                    } else {
-                        widgetEscState = 'idle';
                     }
                 });
             });
@@ -301,9 +296,6 @@
                         }
 
                         if (!inInput) {
-                            if (e.key !== 'Escape') {
-                                widgetEscState = 'idle';
-                            }
                             if (e.key === 'ArrowDown') { moveSelection(1); e.preventDefault(); }
                             else if (e.key === 'ArrowUp') { moveSelection(-1); e.preventDefault(); }
                             else if (e.key === 'ArrowRight') { moveSelectionHorizontal(1); e.preventDefault(); }
@@ -312,20 +304,22 @@
                                 alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows move selection\nEnter - open\nCtrl+Enter - open in background\nEsc twice - clear search and restore view');
                                 e.preventDefault();
                             } else if (e.key === 'Escape') {
-                                if (widgetEscState === 'clear-one' && lastSearchWidget) {
-                                    if (lastSearchWidget.value !== '') {
-                                        lastSearchWidget.value = '';
-                                    }
-                                    widgetEscState = 'clear-all';
-                                } else if (widgetEscState === 'clear-all') {
-                                    document.querySelectorAll('input.search-widget').forEach(function(el){ el.value = ''; });
-                                    if (searchBox && searchBox.value !== '') {
-                                        searchBox.value = '';
-                                        clearSearch();
+                                if (lastSearchWidget && lastSearchWidget.value !== '') {
+                                    lastSearchWidget.value = '';
+                                } else if (document.querySelectorAll('input.search-widget').length > 0) {
+                                    var anyVal = false;
+                                    document.querySelectorAll('input.search-widget').forEach(function(el){ if (el.value !== '') { anyVal = true; } });
+                                    if (anyVal || (searchBox && searchBox.value !== '')) {
+                                        document.querySelectorAll('input.search-widget').forEach(function(el){ el.value = ''; });
+                                        if (searchBox && searchBox.value !== '') {
+                                            searchBox.value = '';
+                                            clearSearch();
+                                        } else if (searchBox) {
+                                            searchBox.blur();
+                                        }
                                     } else if (searchBox) {
                                         searchBox.blur();
                                     }
-                                    widgetEscState = 'idle';
                                     lastSearchWidget = null;
                                 } else if (searchBox && searchBox.value !== '') {
                                     searchBox.value = '';

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -57,7 +57,7 @@
                     var initialHash = '';
                     var initialPage = -1;
                     var lastSearchWidget = null;
-                    var widgetEscStep = 0;
+                    var widgetEscState = 'idle';
 
                     function restoreInitial() {
                         if (initialHash !== '') {
@@ -237,7 +237,7 @@
             document.querySelectorAll('input.search-widget').forEach(function(inp){
                 inp.addEventListener('focus', function(){
                     lastSearchWidget = inp;
-                    widgetEscStep = 0;
+                    widgetEscState = 'idle';
                 });
                 inp.addEventListener('keydown', function(e){
                     if (e.key === 'Enter') {
@@ -255,12 +255,12 @@
                         e.preventDefault();
                     } else if (e.key === 'Escape') {
                         lastSearchWidget = inp;
-                        widgetEscStep = 1;
+                        widgetEscState = 'clear-one';
                         inp.blur();
                         e.preventDefault();
                         e.stopPropagation();
                     } else {
-                        widgetEscStep = 0;
+                        widgetEscState = 'idle';
                     }
                 });
             });
@@ -302,7 +302,7 @@
 
                         if (!inInput) {
                             if (e.key !== 'Escape') {
-                                widgetEscStep = 0;
+                                widgetEscState = 'idle';
                             }
                             if (e.key === 'ArrowDown') { moveSelection(1); e.preventDefault(); }
                             else if (e.key === 'ArrowUp') { moveSelection(-1); e.preventDefault(); }
@@ -312,12 +312,12 @@
                                 alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows move selection\nEnter - open\nCtrl+Enter - open in background\nEsc twice - clear search and restore view');
                                 e.preventDefault();
                             } else if (e.key === 'Escape') {
-                                if (widgetEscStep === 1 && lastSearchWidget) {
+                                if (widgetEscState === 'clear-one' && lastSearchWidget) {
                                     if (lastSearchWidget.value !== '') {
                                         lastSearchWidget.value = '';
                                     }
-                                    widgetEscStep = 2;
-                                } else if (widgetEscStep === 2) {
+                                    widgetEscState = 'clear-all';
+                                } else if (widgetEscState === 'clear-all') {
                                     document.querySelectorAll('input.search-widget').forEach(function(el){ el.value = ''; });
                                     if (searchBox && searchBox.value !== '') {
                                         searchBox.value = '';
@@ -325,7 +325,7 @@
                                     } else if (searchBox) {
                                         searchBox.blur();
                                     }
-                                    widgetEscStep = 0;
+                                    widgetEscState = 'idle';
                                     lastSearchWidget = null;
                                 } else if (searchBox && searchBox.value !== '') {
                                     searchBox.value = '';

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -100,9 +100,18 @@
                         var items = document.querySelectorAll('.bookmark-entries li');
                         items.forEach(function(li) {
                             var a = li.querySelector('a[target="_blank"]');
-                            if (!a) return;
-                            var text = a.textContent.toLowerCase();
-                            var url = a.getAttribute('href').toLowerCase();
+                            var input = li.querySelector('input.search-widget');
+                            var text = '';
+                            var url = '';
+                            if (a) {
+                                text = a.textContent.toLowerCase();
+                                url = a.getAttribute('href').toLowerCase();
+                            } else if (input) {
+                                text = input.getAttribute('placeholder').toLowerCase();
+                                url = (input.dataset.searchUrl || '').toLowerCase();
+                            } else {
+                                return;
+                            }
                             if (text.indexOf(q) !== -1 || url.indexOf(q) !== -1) {
                                 searchResults.push(li);
                             } else {
@@ -195,16 +204,23 @@
                                 e.preventDefault();
                             } else if (e.key === 'Enter') {
                                 if (searchResults.length > 0) {
-                                    var link = searchResults[selectedIndex].querySelector('a');
-                                    if (link) {
-                                        if (e.ctrlKey || e.metaKey) {
-                                            window.open(link.href, '_blank', 'noopener');
-                                        } else if (link.target && link.target === '_blank') {
-                                            window.open(link.href, '_blank');
-                                        } else {
-                                            window.location.href = link.href;
+                                    var li = searchResults[selectedIndex];
+                                    var input = li.querySelector('input.search-widget');
+                                    if (input) {
+                                        input.focus();
+                                        input.select();
+                                    } else {
+                                        var link = li.querySelector('a');
+                                        if (link) {
+                                            if (e.ctrlKey || e.metaKey) {
+                                                window.open(link.href, '_blank', 'noopener');
+                                            } else if (link.target && link.target === '_blank') {
+                                                window.open(link.href, '_blank');
+                                            } else {
+                                                window.location.href = link.href;
+                                            }
+                                            searchBox.focus();
                                         }
-                                        searchBox.focus();
                                     }
                                 }
                                 e.preventDefault();
@@ -215,6 +231,25 @@
                             }
                         });
                     }
+
+            document.querySelectorAll('input.search-widget').forEach(function(inp){
+                inp.addEventListener('keydown', function(e){
+                    if (e.key === 'Enter') {
+                        var url = (inp.dataset.searchUrl || '').replace('$query', encodeURIComponent(inp.value));
+                        if (e.altKey && e.shiftKey) {
+                            window.open(url);
+                        } else if (e.shiftKey) {
+                            window.open(url, '_blank', 'noopener');
+                        } else {
+                            window.open(url, '_blank');
+                        }
+                        if (!e.altKey) {
+                            inp.value = '';
+                        }
+                        e.preventDefault();
+                    }
+                });
+            });
 
                     function changePage(delta) {
                         var pages = document.querySelectorAll('.bookmarkPage[id^="page"]');
@@ -269,16 +304,23 @@
                                 e.preventDefault();
                             } else if (e.key === 'Enter') {
                                 if (searchResults.length > 0) {
-                                    var link = searchResults[selectedIndex].querySelector('a');
-                                    if (link) {
-                                        if (e.ctrlKey || e.metaKey) {
-                                            window.open(link.href, '_blank', 'noopener');
-                                        } else if (link.target && link.target === '_blank') {
-                                            window.open(link.href, '_blank');
-                                        } else {
-                                            window.location.href = link.href;
+                                    var li = searchResults[selectedIndex];
+                                    var input = li.querySelector('input.search-widget');
+                                    if (input) {
+                                        input.focus();
+                                        input.select();
+                                    } else {
+                                        var link = li.querySelector('a');
+                                        if (link) {
+                                            if (e.ctrlKey || e.metaKey) {
+                                                window.open(link.href, '_blank', 'noopener');
+                                            } else if (link.target && link.target === '_blank') {
+                                                window.open(link.href, '_blank');
+                                            } else {
+                                                window.location.href = link.href;
+                                            }
+                                            if (searchBox) searchBox.focus();
                                         }
-                                        if (searchBox) searchBox.focus();
                                     }
                                 }
                             }

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -319,6 +319,12 @@
                                     widgetEscStep = 2;
                                 } else if (widgetEscStep === 2) {
                                     document.querySelectorAll('input.search-widget').forEach(function(el){ el.value = ''; });
+                                    if (searchBox && searchBox.value !== '') {
+                                        searchBox.value = '';
+                                        clearSearch();
+                                    } else if (searchBox) {
+                                        searchBox.blur();
+                                    }
                                     widgetEscStep = 0;
                                     lastSearchWidget = null;
                                 } else if (searchBox && searchBox.value !== '') {

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -56,6 +56,8 @@
                     var selectedIndex = 0;
                     var initialHash = '';
                     var initialPage = -1;
+                    var lastSearchWidget = null;
+                    var widgetEscStep = 0;
 
                     function restoreInitial() {
                         if (initialHash !== '') {
@@ -233,6 +235,10 @@
                     }
 
             document.querySelectorAll('input.search-widget').forEach(function(inp){
+                inp.addEventListener('focus', function(){
+                    lastSearchWidget = inp;
+                    widgetEscStep = 0;
+                });
                 inp.addEventListener('keydown', function(e){
                     if (e.key === 'Enter') {
                         var url = (inp.dataset.searchUrl || '').replace('$query', encodeURIComponent(inp.value));
@@ -247,6 +253,14 @@
                             inp.value = '';
                         }
                         e.preventDefault();
+                    } else if (e.key === 'Escape') {
+                        lastSearchWidget = inp;
+                        widgetEscStep = 1;
+                        inp.blur();
+                        e.preventDefault();
+                        e.stopPropagation();
+                    } else {
+                        widgetEscStep = 0;
                     }
                 });
             });
@@ -287,6 +301,9 @@
                         }
 
                         if (!inInput) {
+                            if (e.key !== 'Escape') {
+                                widgetEscStep = 0;
+                            }
                             if (e.key === 'ArrowDown') { moveSelection(1); e.preventDefault(); }
                             else if (e.key === 'ArrowUp') { moveSelection(-1); e.preventDefault(); }
                             else if (e.key === 'ArrowRight') { moveSelectionHorizontal(1); e.preventDefault(); }
@@ -295,7 +312,16 @@
                                 alert('Keyboard shortcuts:\nAlt+[ and Alt+] - switch page\nAlt+{ and Alt+} - switch tab\nAlt+K - focus search\nArrows move selection\nEnter - open\nCtrl+Enter - open in background\nEsc twice - clear search and restore view');
                                 e.preventDefault();
                             } else if (e.key === 'Escape') {
-                                if (searchBox && searchBox.value !== '') {
+                                if (widgetEscStep === 1 && lastSearchWidget) {
+                                    if (lastSearchWidget.value !== '') {
+                                        lastSearchWidget.value = '';
+                                    }
+                                    widgetEscStep = 2;
+                                } else if (widgetEscStep === 2) {
+                                    document.querySelectorAll('input.search-widget').forEach(function(el){ el.value = ''; });
+                                    widgetEscStep = 0;
+                                    lastSearchWidget = null;
+                                } else if (searchBox && searchBox.value !== '') {
                                     searchBox.value = '';
                                     clearSearch();
                                 } else if (searchBox) {


### PR DESCRIPTION
## Summary
- allow URLs with `search:` scheme to be rendered as custom search widgets
- wire up JS to open search results from these widgets
- integrate widgets with quick search navigation
- document search widget usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d7ed44988832f92fd99f3b8aabcbb