### PR TITLE
Remove Page prefix from named pages

### DIFF
--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -42,7 +42,7 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                              <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?edit=1{{if tab}}&tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">Page {{ if $p.IndexName }}{{$p.IndexName}}{{ else }}{{ add1 $i }}{{ end }}</a></li>
+                                                        <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?edit=1{{if tab}}&tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">{{ if $p.IndexName }}{{$p.IndexName}}{{ else }}Page {{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
                                                                 <li><a href="/editPage?edit=1&ref={{ref}}&tab={{tab}}">+ Add Page</a></li>


### PR DESCRIPTION
## Summary
- simplify page index display so named pages aren't prefixed with "Page"

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dac15c550832f8cc1a01f710862f9