### PR TITLE
Restrict builds to runner architecture

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,8 @@ builds:
     env:
       - CGO_ENABLED=1
     flags: ["-trimpath"]
-    goos: [linux, windows, darwin, freebsd]
-    goarch: [amd64, arm64]
+    goos: ["{{ .Env.GOOS }}"]
+    goarch: ["{{ .Env.GOARCH }}"]
 
 archives:
   -
@@ -31,37 +31,15 @@ dockers:
       - "arran4/gobookmarks:latest"
     dockerfile: Dockerfile
     goos: linux
-    goarch: amd64
+    goarch: "{{ .Env.GOARCH }}"
     use: buildx
   - image_templates:
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-amd64"
-      - "ghcr.io/arran4/gobookmarks:latest-amd64"
+      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}"
+      - "ghcr.io/arran4/gobookmarks:latest"
     dockerfile: Dockerfile
     goos: linux
-    goarch: amd64
+    goarch: "{{ .Env.GOARCH }}"
     use: buildx
-  - image_templates:
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-arm64"
-      - "ghcr.io/arran4/gobookmarks:latest-arm64"
-    dockerfile: Dockerfile
-    goos: linux
-    goarch: arm64
-    use: buildx
-docker_manifests:
-  - name_template: "arran4/gobookmarks:{{ .Tag }}"
-    image_templates:
-      - "arran4/gobookmarks:{{ .Tag }}"
-  - name_template: "arran4/gobookmarks:latest"
-    image_templates:
-      - "arran4/gobookmarks:latest"
-  - name_template: "ghcr.io/arran4/gobookmarks:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-amd64"
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-arm64"
-  - name_template: "ghcr.io/arran4/gobookmarks:latest"
-    image_templates:
-      - "ghcr.io/arran4/gobookmarks:latest-amd64"
-      - "ghcr.io/arran4/gobookmarks:latest-arm64"
 nfpms:
   -
     vendor: Ubels Software Development


### PR DESCRIPTION
## Summary
- build only for the runner's GOOS and GOARCH using env vars
- publish docker images only for the runner architecture

## Testing
- `go test ./...`
- `goreleaser check` *(fails: configuration is invalid: no remote configured to list refs from)*

------
https://chatgpt.com/codex/tasks/task_e_689136296de0832fb8f245bfa9a8de6f