### PR TITLE
Use 1-based page anchors

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -677,7 +677,11 @@ func redirectToHandlerBranchToRef(toUrl string) func(http.ResponseWriter, *http.
 			page = v
 		}
 		if page != "" {
-			u.Fragment = "page" + page
+			if p, err := strconv.Atoi(page); err == nil {
+				u.Fragment = "page" + strconv.Itoa(p+1)
+			} else {
+				u.Fragment = "page" + page
+			}
 		}
 		if edit := r.URL.Query().Get("edit"); edit != "" {
 			qs.Set("edit", edit)
@@ -695,7 +699,11 @@ func redirectToHandlerTabPage(toUrl string) func(http.ResponseWriter, *http.Requ
 			qs.Set("tab", tab)
 		}
 		if page := r.URL.Query().Get("page"); page != "" {
-			u.Fragment = "page" + page
+			if p, err := strconv.Atoi(page); err == nil {
+				u.Fragment = "page" + strconv.Itoa(p+1)
+			} else {
+				u.Fragment = "page" + page
+			}
 		}
 		if edit := r.URL.Query().Get("edit"); edit != "" {
 			qs.Set("edit", edit)

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -42,7 +42,7 @@
                                                 <b>Pages</b>
                                                 <ul id="page-list" style="list-style-type:none;padding-left:0;">
                                                         {{- range $i, $p := bookmarkPages }}
-                                                        <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?edit=1{{if tab}}&tab={{tab}}{{end}}#page{{$i}}{{else}}#page{{$i}}{{end}}">{{ if $p.IndexName }}{{$p.IndexName}}{{ else }}Page {{ add1 $i }}{{ end }}</a></li>
+                                                       <li data-page-sha="{{$p.Sha}}"><span class="move-handle">&#9776;</span><a href="{{if $.EditMode}}/?edit=1{{if tab}}&tab={{tab}}{{end}}#page{{ add1 $i }}{{else}}#page{{ add1 $i }}{{end}}">{{ if $p.IndexName }}{{$p.IndexName}}{{ else }}Page {{ add1 $i }}{{ end }}</a></li>
                                                         {{- end }}
                                                         {{- if $.EditMode }}
                                                                 <li><a href="/editPage?edit=1&ref={{ref}}&tab={{tab}}">+ Add Page</a></li>

--- a/templates/mainPage.gohtml
+++ b/templates/mainPage.gohtml
@@ -6,7 +6,7 @@
         <p>Your bookmarks repository was not found. Click <a href="/edit">here</a> to create it.</p>
         {{- end }}
         {{- range $i, $p := bookmarkPages }}
-        <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{$i}}" data-sha="{{$p.Sha}}">
+        <div class="bookmarkPage{{ if useCssColumns }} cssColumns{{ end }}" id="page{{ add1 $i }}" data-sha="{{$p.Sha}}">
             {{- if and (eq $i 0) tab }}<h1>{{ tabName }} <a class="edit-link" href="/editTab?edit=1&name={{ tabName }}&ref={{ref}}&tab={{tab}}" title="Edit">&#9998;</a></h1>{{ end }}
             {{- if $p.Name }}<h2>{{ $p.Name }}</h2>{{ end }}
             {{- range .Blocks }}

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -42,7 +42,7 @@
                             if (page >= 0) {
                                 var url = new URL(link.getAttribute('href'), window.location);
                                 url.searchParams.set('page', page);
-                                url.hash = 'page' + page;
+                                url.hash = 'page' + (page + 1);
                                 e.preventDefault();
                                 window.location.href = url.toString();
                             }


### PR DESCRIPTION
## Summary
- Adjust page fragment links and IDs to use 1-based numbering for user-visible anchors
- Update redirects and client scripts so hashes append page+1

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae8963ccd8832f8d314e3f8d00bc83