### PR TITLE
Improve auth error handling with request replay

### DIFF
--- a/cmd/gobookmarks/main_test.go
+++ b/cmd/gobookmarks/main_test.go
@@ -66,3 +66,66 @@ func TestRunTemplate_BufferedError(t *testing.T) {
 		t.Fatalf("unexpected partial page content: %q", body)
 	}
 }
+
+func TestRedirectToHandler_ReplaysPostRequest(t *testing.T) {
+	gb.SessionName = "testsess"
+	gb.SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	req := httptest.NewRequest("GET", "/oauth2Callback", nil)
+	sess, _ := gb.SessionStore.New(req, gb.SessionName)
+	ctx := context.WithValue(req.Context(), gb.ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+
+	gb.StoreRequestReplay(sess, &gb.RequestReplay{
+		Method:      "POST",
+		URL:         "/edit",
+		EncodedForm: "task=Save&ref=main",
+	})
+
+	w := httptest.NewRecorder()
+	redirectToHandler("/")(w, req)
+
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected html replay, got %d", res.StatusCode)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "id=\"return-form\"") {
+		t.Fatalf("expected replay form, got %q", body)
+	}
+	if !strings.Contains(body, "name=\"task\" value=\"Save\"") {
+		t.Fatalf("expected task field in replay form: %q", body)
+	}
+	if _, ok := sess.Values["return:url"]; ok {
+		t.Fatalf("return url not cleared")
+	}
+}
+
+func TestRedirectToHandler_RedirectsGetRequest(t *testing.T) {
+	gb.SessionName = "testsess"
+	gb.SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	req := httptest.NewRequest("GET", "/oauth2Callback", nil)
+	sess, _ := gb.SessionStore.New(req, gb.SessionName)
+	ctx := context.WithValue(req.Context(), gb.ContextValues("session"), sess)
+	req = req.WithContext(ctx)
+
+	gb.StoreRequestReplay(sess, &gb.RequestReplay{
+		Method: "GET",
+		URL:    "/history",
+	})
+
+	w := httptest.NewRecorder()
+	redirectToHandler("/")(w, req)
+
+	res := w.Result()
+	if res.StatusCode != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", res.StatusCode)
+	}
+	if loc := res.Header.Get("Location"); loc != "/history" {
+		t.Fatalf("redirect location mismatch: %s", loc)
+	}
+	if _, ok := sess.Values["return:url"]; ok {
+		t.Fatalf("return url not cleared")
+	}
+}

--- a/error_page.go
+++ b/error_page.go
@@ -1,0 +1,186 @@
+package gobookmarks
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/sessions"
+)
+
+const (
+	sessionReturnURLKey    = "return:url"
+	sessionReturnMethodKey = "return:method"
+	sessionReturnBodyKey   = "return:body"
+)
+
+// RequestReplay captures enough information about a request so it can be
+// repeated after the user signs in again.
+type RequestReplay struct {
+	Method      string
+	URL         string
+	Form        url.Values
+	EncodedForm string
+}
+
+// HasForm reports whether the replay contains form data.
+func (r *RequestReplay) HasForm() bool {
+	return r != nil && len(r.Form) > 0
+}
+
+// CaptureRequestReplay builds a RequestReplay for the supplied request. Only
+// form data encoded as application/x-www-form-urlencoded is captured.
+func CaptureRequestReplay(req *http.Request) *RequestReplay {
+	if req == nil {
+		return nil
+	}
+
+	rr := &RequestReplay{
+		Method: strings.ToUpper(req.Method),
+	}
+	if req.URL != nil {
+		rr.URL = req.URL.RequestURI()
+	}
+	if rr.URL == "" {
+		rr.URL = "/"
+	}
+
+	switch req.Method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		if err := req.ParseForm(); err == nil && len(req.PostForm) > 0 {
+			form := url.Values{}
+			for k, vals := range req.PostForm {
+				copyVals := append([]string(nil), vals...)
+				form[k] = copyVals
+			}
+			rr.Form = form
+			rr.EncodedForm = form.Encode()
+		}
+	}
+
+	rr.URL = sanitizeReturnURL(rr.URL)
+	return rr
+}
+
+// ErrorPageData is passed to the shared error template. It implements the
+// error interface so template helpers can inspect the underlying cause.
+type ErrorPageData struct {
+	*CoreData
+	error
+	Message       string
+	RequestReplay *RequestReplay
+}
+
+// Error implements the error interface.
+func (d ErrorPageData) Error() string {
+	if d.error != nil {
+		return d.error.Error()
+	}
+	return d.Message
+}
+
+// Unwrap exposes the underlying error for errors.Is/As.
+func (d ErrorPageData) Unwrap() error { return d.error }
+
+// NewErrorPageData constructs ErrorPageData for the current request.
+func NewErrorPageData(r *http.Request, err error, display string) ErrorPageData {
+	core, _ := r.Context().Value(ContextValues("coreData")).(*CoreData)
+	data := ErrorPageData{
+		CoreData:      core,
+		error:         err,
+		Message:       display,
+		RequestReplay: CaptureRequestReplay(r),
+	}
+	if data.error == nil && display != "" {
+		data.error = errors.New(display)
+	}
+	return data
+}
+
+// StoreRequestReplay persists the replay information in the session so it can
+// be replayed after the user logs in again.
+func StoreRequestReplay(session *sessions.Session, replay *RequestReplay) {
+	if session == nil {
+		return
+	}
+	if replay == nil {
+		delete(session.Values, sessionReturnURLKey)
+		delete(session.Values, sessionReturnMethodKey)
+		delete(session.Values, sessionReturnBodyKey)
+		return
+	}
+
+	dest := sanitizeReturnURL(replay.URL)
+	if dest == "" {
+		delete(session.Values, sessionReturnURLKey)
+		delete(session.Values, sessionReturnMethodKey)
+		delete(session.Values, sessionReturnBodyKey)
+		return
+	}
+
+	method := strings.ToUpper(replay.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	session.Values[sessionReturnURLKey] = dest
+	session.Values[sessionReturnMethodKey] = method
+	if replay.EncodedForm != "" {
+		session.Values[sessionReturnBodyKey] = replay.EncodedForm
+	} else {
+		delete(session.Values, sessionReturnBodyKey)
+	}
+}
+
+// ConsumeRequestReplay retrieves and clears the replay information from the
+// session. It returns nil when no replay data is stored.
+func ConsumeRequestReplay(session *sessions.Session) *RequestReplay {
+	if session == nil {
+		return nil
+	}
+	rawURL, _ := session.Values[sessionReturnURLKey].(string)
+	if rawURL == "" {
+		return nil
+	}
+
+	method, _ := session.Values[sessionReturnMethodKey].(string)
+	if method == "" {
+		method = http.MethodGet
+	}
+	body, _ := session.Values[sessionReturnBodyKey].(string)
+
+	delete(session.Values, sessionReturnURLKey)
+	delete(session.Values, sessionReturnMethodKey)
+	delete(session.Values, sessionReturnBodyKey)
+
+	replay := &RequestReplay{
+		Method:      strings.ToUpper(method),
+		URL:         rawURL,
+		EncodedForm: body,
+	}
+	if body != "" {
+		if form, err := url.ParseQuery(body); err == nil {
+			replay.Form = form
+		}
+	}
+	return replay
+}
+
+func sanitizeReturnURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if u.Scheme != "" || u.Host != "" {
+		return ""
+	}
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	u.Fragment = ""
+	return u.String()
+}

--- a/funcs.go
+++ b/funcs.go
@@ -81,6 +81,12 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			return creds != nil && GetProvider(p) != nil
 		},
 		"errorMsg": errorMessage,
+		"IsAuthenticationError": func(err error) bool {
+			if err == nil {
+				return false
+			}
+			return errors.Is(err, ErrSignedOut)
+		},
 		"ref": func() string {
 			return r.URL.Query().Get("ref")
 		},

--- a/templates/error.gohtml
+++ b/templates/error.gohtml
@@ -11,7 +11,45 @@
                 <strong>gobookmarks</strong><br>
             </td>
             <td>
-                <p>Error: {{.Error}}</p>
+                <h1>Error</h1>
+                <p>{{.Message}}</p>
+                {{ $replay := .RequestReplay }}
+                {{ if $replay }}
+                <div class="error-actions" style="margin-top: 1em;">
+                    <p>You can try your previous action again.</p>
+                    {{ if eq $replay.Method "GET" }}
+                    <form action="{{ $replay.URL }}" method="get" style="display:inline-block; margin-right: 1em;">
+                        <button type="submit">Retry</button>
+                    </form>
+                    {{ else if eq $replay.Method "POST" }}
+                    <form action="{{ $replay.URL }}" method="post" style="display:inline-block; margin-right: 1em;">
+                        {{ range $name, $vals := $replay.Form }}
+                            {{ range $vals }}
+                        <input type="hidden" name="{{ $name }}" value="{{ . }}">
+                            {{ end }}
+                        {{ end }}
+                        <button type="submit">Retry</button>
+                    </form>
+                    {{ else }}
+                    <a href="{{ $replay.URL }}">Retry</a>
+                    {{ end }}
+                </div>
+                {{ end }}
+                {{ if IsAuthenticationError . }}
+                <p>Your authentication details are no longer valid. Please log out and sign in again.</p>
+                <form action="/logout" method="post" style="margin-top: 1em;">
+                    {{ if $replay }}
+                    <input type="hidden" name="return_url" value="{{ $replay.URL }}">
+                    <input type="hidden" name="return_method" value="{{ $replay.Method }}">
+                    {{ if $replay.EncodedForm }}
+                    <input type="hidden" name="return_body" value="{{ $replay.EncodedForm }}">
+                    {{ end }}
+                    {{ else }}
+                    <input type="hidden" name="return_method" value="GET">
+                    {{ end }}
+                    <button type="submit">Logout</button>
+                </form>
+                {{ end }}
             </td>
         </tr>
     </table>


### PR DESCRIPTION
## Summary
- add request replay helpers to capture the failing request and persist it through logout
- update logout and error flows to embed request details and surface retry/logout controls in the error page
- adjust redirect handlers to replay stored requests after login and expand tests/template helpers for the new behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c9211d33b8832fa82d6d6ab27ee99b