### PR TITLE
Integrate manual dispatch into GoReleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git reference to checkout (branch, tag or commit)'
+        required: true
+        default: main
+      publish:
+        description: 'Publish release artifacts and push Docker images'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -17,30 +28,69 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
+      - name: Determine publish mode
+        id: publish
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_INPUT: ${{ github.event.inputs.publish }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$PUBLISH_INPUT" != "true" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Login to GitHub Container Registry
+        if: steps.publish.outputs.publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
+        if: steps.publish.outputs.publish == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Enable Docker Hub push
+        if: steps.publish.outputs.publish == 'true'
         run: echo "DOCKERHUB_PUSH=true" >> "$GITHUB_ENV"
+      - name: Disable Docker Hub push
+        if: steps.publish.outputs.publish != 'true'
+        run: echo "DOCKERHUB_PUSH=false" >> "$GITHUB_ENV"
       - name: Env setup
         run: |
-          sudo apt-get install build-essential
+          sudo apt-get update
+          sudo apt-get install -y build-essential
       - name: Test
         run: go test ./...
-      - name: Run GoReleaser
+      - name: Build gobookmarks binary for Docker smoke test
+        run: go build -o gobookmarks ./cmd/gobookmarks
+      - name: Build Docker image (smoke test)
+        run: docker build --tag gobookmarks:test .
+      - name: Smoke test Docker image
+        run: docker run --rm gobookmarks:test --version
+      - name: Clean up Docker smoke test artifacts
+        run: |
+          rm -f gobookmarks
+          docker image rm gobookmarks:test || true
+      - name: Run GoReleaser (snapshot)
+        if: steps.publish.outputs.publish != 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --skip=publish --skip=announce --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser (publish)
+        if: steps.publish.outputs.publish == 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser


### PR DESCRIPTION
## Summary
- add a workflow_dispatch trigger and publish controls to the existing GoReleaser workflow
- reuse the shared release steps for manual snapshot or publish runs
- remove the redundant manual test workflow file
- add a Docker smoke test stage so images are exercised before GoReleaser publishes them

## Testing
- not run (workflow-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68db526ea7f0832fb2fd2e1d1315960f