### PR TITLE
Support snapshot releases in GoReleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -45,6 +45,16 @@ jobs:
           else
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
+      - name: Determine git tag status
+        id: git_state
+        run: |
+          if git describe --exact-match --tags >/dev/null 2>&1; then
+            echo "tagged=true" >> "$GITHUB_OUTPUT"
+            echo "LATEST_TAG=latest" >> "$GITHUB_ENV"
+          else
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+            echo "LATEST_TAG=disabled" >> "$GITHUB_ENV"
+          fi
       - name: Login to GitHub Container Registry
         if: steps.publish.outputs.publish == 'true'
         uses: docker/login-action@v3
@@ -90,11 +100,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser (publish)
-        if: steps.publish.outputs.publish == 'true'
+        if: steps.publish.outputs.publish == 'true' && steps.git_state.outputs.tagged == 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
           args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run GoReleaser (publish snapshot)
+        if: steps.publish.outputs.publish == 'true' && steps.git_state.outputs.tagged != 'true'
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --snapshot --skip=announce
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  version_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ .ShortCommit }}"
 changelog:
   sort: asc
   filters:
@@ -29,27 +29,21 @@ changelog:
       - '^test:'
 dockers:
   - image_templates:
-      - "arran4/gobookmarks:{{ .Tag }}"
-      - "arran4/gobookmarks:latest"
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-{{.Runtime.Goarch}}"
-      - "ghcr.io/arran4/gobookmarks:latest-{{.Runtime.Goarch}}"
+      - "arran4/gobookmarks:{{ .Version }}"
+      - '{{- if ne .Env.LATEST_TAG "disabled" }}arran4/gobookmarks:{{ .Env.LATEST_TAG }}{{ end -}}'
+      - "ghcr.io/arran4/gobookmarks:{{ .Version }}-{{ .Runtime.Goarch }}"
+      - '{{- if ne .Env.LATEST_TAG "disabled" }}ghcr.io/arran4/gobookmarks:{{ .Env.LATEST_TAG }}-{{ .Runtime.Goarch }}{{ end -}}'
     dockerfile: Dockerfile
     goos: linux
     goarch: amd64
     use: buildx
 docker_manifests:
-  - name_template: "arran4/gobookmarks:{{ .Tag }}"
+  - name_template: "arran4/gobookmarks:{{ .Version }}"
     image_templates:
-      - "arran4/gobookmarks:{{ .Tag }}"
-  - name_template: "arran4/gobookmarks:latest"
+      - "arran4/gobookmarks:{{ .Version }}"
+  - name_template: "ghcr.io/arran4/gobookmarks:{{ .Version }}"
     image_templates:
-      - "arran4/gobookmarks:latest"
-  - name_template: "ghcr.io/arran4/gobookmarks:{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/arran4/gobookmarks:{{ .Tag }}-{{.Runtime.Goarch}}"
-  - name_template: "ghcr.io/arran4/gobookmarks:latest"
-    image_templates:
-      - "ghcr.io/arran4/gobookmarks:latest-{{.Runtime.Goarch}}"
+      - "ghcr.io/arran4/gobookmarks:{{ .Version }}-{{ .Runtime.Goarch }}"
 nfpms:
   -
     vendor: Ubels Software Development


### PR DESCRIPTION
## Summary
- detect whether the workflow is running on a tagged commit and set Docker tagging controls accordingly
- publish snapshot releases via GoReleaser when publishing from untagged commits
- update GoReleaser image templates to use the build version/commit hash while keeping `latest` tags for tagged releases

## Testing
- go test ./... *(fails to complete locally; aborted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e090ec8c20832fb2ef556fcb5991fd