### PR TITLE
Fix errcheck linting issues

### DIFF
--- a/cmd/gobookmarks/db_users_command.go
+++ b/cmd/gobookmarks/db_users_command.go
@@ -57,7 +57,7 @@ func (c *DbUsersCommand) Execute(args []string) error {
 		printHelp(c, err)
 		return err
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	rows, err := db.Query("SELECT user FROM passwords")
 	if err != nil {

--- a/cmd/gobookmarks/help_command.go
+++ b/cmd/gobookmarks/help_command.go
@@ -40,7 +40,7 @@ func (c *HelpCommand) Execute(args []string) error {
 			}
 		}
 	}
-	c.FlagSet().Parse(args)
+	_ = c.FlagSet().Parse(args)
 	c.FlagSet().Usage = func() {}
 	printHelp(target, nil)
 	return nil

--- a/cmd/gobookmarks/serve.go
+++ b/cmd/gobookmarks/serve.go
@@ -452,7 +452,7 @@ func CreatePEMFiles() {
 	if err != nil {
 		log.Fatalf("Failed to create cert.pem file: %v", err)
 	}
-	defer certFile.Close()
+	defer func() { _ = certFile.Close() }()
 	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
 		log.Fatalf("Failed to write data to cert.pem: %v", err)
 	}
@@ -461,7 +461,7 @@ func CreatePEMFiles() {
 	if err != nil {
 		log.Fatalf("Failed to create key.pem file: %v", err)
 	}
-	defer keyFile.Close()
+	defer func() { _ = keyFile.Close() }()
 	privBytes, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
 		log.Fatalf("Failed to marshal private key: %v", err)

--- a/cmd/gobookmarks/test_verification_template_command.go
+++ b/cmd/gobookmarks/test_verification_template_command.go
@@ -303,7 +303,7 @@ https://example.com Example Link
 		// For serving, we need to handle main.css and favicon too, otherwise the page looks broken
 		mux := http.NewServeMux()
 		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			w.Write(output)
+			_, _ = w.Write(output)
 		})
 		mux.HandleFunc("/main.css", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/css")

--- a/config.go
+++ b/config.go
@@ -280,7 +280,7 @@ func LoadEnvFile(path string) error {
 		}
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -295,7 +295,7 @@ func LoadEnvFile(path string) error {
 		key := strings.TrimSpace(parts[0])
 		val := strings.TrimSpace(parts[1])
 		if os.Getenv(key) == "" {
-			os.Setenv(key, val)
+			_ = os.Setenv(key, val)
 		}
 	}
 	return scanner.Err()

--- a/db.go
+++ b/db.go
@@ -20,12 +20,12 @@ func OpenDB() (*sql.DB, error) {
 	}
 
 	if err := db.Ping(); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, NewSystemError("Database error", err)
 	}
 
 	if err := ensureSQLSchema(db); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, NewSystemError("Database error", fmt.Errorf("failed to ensure schema: %w", err))
 	}
 	return db, nil

--- a/favicon_proxy_test.go
+++ b/favicon_proxy_test.go
@@ -12,13 +12,13 @@ func newFaviconServer(t *testing.T, icon []byte) (*httptest.Server, *int) {
 	hits := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("<link rel='icon' href='/favicon.ico'>"))
+		_, _ = w.Write([]byte("<link rel='icon' href='/favicon.ico'>"))
 	})
 	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		hits++
 		w.Header().Set("Cache-Control", "max-age=1")
 		w.Header().Set("Content-Type", "image/png")
-		w.Write(icon)
+		_, _ = w.Write(icon)
 	})
 	return httptest.NewServer(mux), &hits
 }


### PR DESCRIPTION
This PR addresses the missing error checks found by the `errcheck` linter. It does not alter behavior but explicitly discards errors to satisfy static analysis checks where the errors are intentionally ignored or handled by other mechanisms.

---
*PR created automatically by Jules for task [14819175034224691817](https://jules.google.com/task/14819175034224691817) started by @arran4*