### PR TITLE
Fix adding a new tab overwriting the first tab

### DIFF
--- a/tabEditHandlers.go
+++ b/tabEditHandlers.go
@@ -33,7 +33,8 @@ func EditTabPage(w http.ResponseWriter, r *http.Request) error {
 	}
 	text := ""
 	tabFromQuery := tabName != ""
-	isAddMode := !HasTabParam(r) && tabName == ""
+	hasTabParam := HasTabParam(r)
+	isAddMode := !hasTabParam && tabName == ""
 	if !isAddMode {
 		if tabName == "" && tabIdx < len(tabs) {
 			tabName = tabs[tabIdx].Name
@@ -104,7 +105,9 @@ func TabEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 
 	var updated string
 	newIndex := len(ParseBookmarks(currentBookmarks))
-	if HasTabParam(r) && tabIdx >= 0 && tabIdx < len(ParseBookmarks(currentBookmarks)) {
+	hasTabParam := HasTabParam(r)
+
+	if hasTabParam && tabIdx >= 0 && tabIdx < len(ParseBookmarks(currentBookmarks)) {
 		updated, err = ReplaceTabByIndex(currentBookmarks, tabIdx, name, text)
 		if err != nil {
 			return fmt.Errorf("ReplaceTabByIndex: %w", err)

--- a/tabEditHandlers.go
+++ b/tabEditHandlers.go
@@ -33,7 +33,7 @@ func EditTabPage(w http.ResponseWriter, r *http.Request) error {
 	}
 	text := ""
 	tabFromQuery := tabName != ""
-	isAddMode := !r.URL.Query().Has("tab") && tabName == ""
+	isAddMode := !HasTabParam(r) && tabName == ""
 	if !isAddMode {
 		if tabName == "" && tabIdx < len(tabs) {
 			tabName = tabs[tabIdx].Name
@@ -104,7 +104,7 @@ func TabEditSaveAction(w http.ResponseWriter, r *http.Request) error {
 
 	var updated string
 	newIndex := len(ParseBookmarks(currentBookmarks))
-	if tabIdx >= 0 && tabIdx < len(ParseBookmarks(currentBookmarks)) {
+	if HasTabParam(r) && tabIdx >= 0 && tabIdx < len(ParseBookmarks(currentBookmarks)) {
 		updated, err = ReplaceTabByIndex(currentBookmarks, tabIdx, name, text)
 		if err != nil {
 			return fmt.Errorf("ReplaceTabByIndex: %w", err)

--- a/tab_add_http_test.go
+++ b/tab_add_http_test.go
@@ -1,0 +1,88 @@
+package gobookmarks
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"golang.org/x/oauth2"
+	"github.com/gorilla/sessions"
+)
+
+type MockProviderForAddTab struct {
+	FileContents string
+	Sha          string
+}
+
+func (m *MockProviderForAddTab) Name() string { return "Mock" }
+func (m *MockProviderForAddTab) Config(clientID, clientSecret, redirectURL string) *oauth2.Config { return nil }
+func (m *MockProviderForAddTab) CurrentUser(ctx context.Context, token *oauth2.Token) (*User, error) { return nil, nil }
+func (m *MockProviderForAddTab) GetTags(ctx context.Context, user string, token *oauth2.Token) ([]*Tag, error) { return nil, nil }
+func (m *MockProviderForAddTab) GetBranches(ctx context.Context, user string, token *oauth2.Token) ([]*Branch, error) { return nil, nil }
+func (m *MockProviderForAddTab) GetCommits(ctx context.Context, user string, token *oauth2.Token, ref string, page, perPage int) ([]*Commit, error) { return nil, nil }
+func (m *MockProviderForAddTab) GetBookmarks(ctx context.Context, user, ref string, token *oauth2.Token) (string, string, error) {
+	return m.FileContents, m.Sha, nil
+}
+func (m *MockProviderForAddTab) UpdateBookmarks(ctx context.Context, user string, token *oauth2.Token, sourceRef, branch, text, expectSHA string) error {
+	m.FileContents = text
+	m.Sha = "new-sha"
+	return nil
+}
+func (m *MockProviderForAddTab) CreateBookmarks(ctx context.Context, user string, token *oauth2.Token, branch, text string) error { return nil }
+func (m *MockProviderForAddTab) CreateRepo(ctx context.Context, user string, token *oauth2.Token, name string) error { return nil }
+func (m *MockProviderForAddTab) RepoExists(ctx context.Context, user string, token *oauth2.Token, name string) (bool, error) { return true, nil }
+func (m *MockProviderForAddTab) DefaultServer() string { return "" }
+
+func TestTabAddIntegration(t *testing.T) {
+	bookmarksStr := `Tab: Tab1
+Page: P1
+
+Tab: Tab2
+Page: P2`
+
+	provider := &MockProviderForAddTab{
+		FileContents: bookmarksStr,
+		Sha:          "mock-sha",
+	}
+	RegisterProvider(provider)
+
+	session := &sessions.Session{
+		Values: map[interface{}]interface{}{
+			"GithubUser": &User{Login: "testuser"},
+		},
+	}
+
+	form := url.Values{}
+	form.Add("name", "NewTab")
+	form.Add("text", "Page: P3")
+	form.Add("task", TaskSaveAndStopEditing)
+
+	req, _ := http.NewRequest("POST", "/editTab", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	ctx = context.WithValue(ctx, ContextValues("provider"), "Mock")
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	err := TabEditSaveAction(rr, req)
+	if err != nil {
+		t.Fatalf("TabEditSaveAction failed: %v", err)
+	}
+
+	// Verify the tab was added to the end and not replacing Tab1
+	parsed := ParseBookmarks(provider.FileContents)
+	if len(parsed) != 3 {
+		t.Fatalf("Expected 3 tabs, got %d. Contents: \n%s", len(parsed), provider.FileContents)
+	}
+
+	if parsed[0].Name != "Tab1" {
+		t.Errorf("Expected 0th tab to be Tab1, got %s", parsed[0].Name)
+	}
+	if parsed[2].Name != "NewTab" {
+		t.Errorf("Expected 2nd tab to be NewTab, got %s", parsed[2].Name)
+	}
+}

--- a/tab_utils.go
+++ b/tab_utils.go
@@ -96,3 +96,26 @@ func PageFragmentFromIndex(pageStr string) string {
 	}
 	return "page" + pageStr
 }
+
+// HasTabParam checks if the tab parameter was provided in the request
+func HasTabParam(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if vars := mux.Vars(r); vars != nil {
+		if _, ok := vars["tab"]; ok {
+			return true
+		}
+	}
+	if r.URL.Query().Has("tab") {
+		return true
+	}
+	if r.Method == "POST" && r.PostForm != nil && r.PostForm.Has("tab") {
+		return true
+	}
+	// Fallback to checking the raw query or form, just in case
+	if r.FormValue("tab") != "" {
+	    return true
+	}
+	return false
+}

--- a/tab_utils.go
+++ b/tab_utils.go
@@ -11,27 +11,33 @@ import (
 
 // TabFromRequest extracts the tab index from either the path parameters or the query string.
 func TabFromRequest(r *http.Request) int {
+	idx, _ := TabFromRequestWithStatus(r)
+	return idx
+}
+
+// TabFromRequestWithStatus extracts the tab index and returns whether it was provided.
+func TabFromRequestWithStatus(r *http.Request) (int, bool) {
 	if r == nil {
-		return 0
+		return 0, false
 	}
 	if vars := mux.Vars(r); vars != nil {
 		if tabStr, ok := vars["tab"]; ok {
 			if tabIdx, err := strconv.Atoi(tabStr); err == nil {
-				return tabIdx
+				return tabIdx, true
 			}
 		}
 	}
 	if tabS := r.URL.Query().Get("tab"); tabS != "" {
 		if tabI, err := strconv.Atoi(tabS); err == nil {
-			return tabI
+			return tabI, true
 		}
 	}
 	if tabS := r.PostFormValue("tab"); tabS != "" {
 		if tabI, err := strconv.Atoi(tabS); err == nil {
-			return tabI
+			return tabI, true
 		}
 	}
-	return 0
+	return 0, false
 }
 
 // TabPath returns the semantic path for a tab index (0 is the root tab).
@@ -99,23 +105,21 @@ func PageFragmentFromIndex(pageStr string) string {
 
 // HasTabParam checks if the tab parameter was provided in the request
 func HasTabParam(r *http.Request) bool {
-	if r == nil {
-		return false
-	}
-	if vars := mux.Vars(r); vars != nil {
-		if _, ok := vars["tab"]; ok {
-			return true
-		}
-	}
-	if r.URL.Query().Has("tab") {
-		return true
-	}
-	if r.Method == "POST" && r.PostForm != nil && r.PostForm.Has("tab") {
-		return true
-	}
+	_, ok := TabFromRequestWithStatus(r)
+    if ok {
+        return true
+    }
 	// Fallback to checking the raw query or form, just in case
-	if r.FormValue("tab") != "" {
-	    return true
-	}
+    if r != nil {
+	    if r.URL.Query().Has("tab") {
+		    return true
+	    }
+	    if r.Method == "POST" && r.PostForm != nil && r.PostForm.Has("tab") {
+		    return true
+	    }
+	    if r.FormValue("tab") != "" {
+	        return true
+	    }
+    }
 	return false
 }


### PR DESCRIPTION
This patch fixes an issue where adding a new tab while in edit mode would incorrectly overwrite the first tab (at index 0). The root cause was that `TabFromRequest` defaults to index 0 when no tab parameter is present. `TabEditSaveAction` was executing its update logic simply because `tabIdx >= 0 && tabIdx < len(tabs)` evaluated to true. 

I've fixed this by explicitly introducing `HasTabParam` to differentiate an Add from an Edit. The logic now correctly appends the newly created tab to the end. An integration test has been added to ensure this correctly handles the "Add" mode.

---
*PR created automatically by Jules for task [16037864037691985766](https://jules.google.com/task/16037864037691985766) started by @arran4*