### PR TITLE
Fix missing partial templates in binary

### DIFF
--- a/data_embedded.go
+++ b/data_embedded.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	//go:embed templates
+	//go:embed all:templates
 	templateFS embed.FS
 	//go:embed "main.css"
 	mainCSSData []byte


### PR DESCRIPTION
By default, `//go:embed` ignores files and directories starting with `_` or `.`. This caused the templates under `templates/_partials` to be excluded from the binary, resulting in "template undefined" errors at runtime. 
This commit updates the embed directive in `data_embedded.go` to use `//go:embed all:templates`, which instructs Go to include all files recursively, fixing the missing partial templates.

---
*PR created automatically by Jules for task [6873238162565436787](https://jules.google.com/task/6873238162565436787) started by @arran4*