### PR TITLE
feat: preserve current page and redirect back after login

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -86,7 +86,7 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	session.Values["Provider"] = providerName
-	if redirect := r.URL.Query().Get("redirect"); redirect != "" {
+	if redirect := r.URL.Query().Get("redirect"); redirect != "" && len(redirect) < 2048 {
 		session.Values["Redirect"] = redirect
 	}
 	if err := session.Save(r, w); err != nil {

--- a/authHandlers.go
+++ b/authHandlers.go
@@ -86,6 +86,9 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	session.Values["Provider"] = providerName
+	if redirect := r.URL.Query().Get("redirect"); redirect != "" {
+		session.Values["Redirect"] = redirect
+	}
 	if err := session.Save(r, w); err != nil {
 		return fmt.Errorf("session save: %w", err)
 	}

--- a/cmd/gobookmarks/serve.go
+++ b/cmd/gobookmarks/serve.go
@@ -618,17 +618,19 @@ func redirectToHandler(toURL string) func(http.ResponseWriter, *http.Request) {
 			}
 		}
 
-		if redirect != "" && strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") {
-			if strings.HasPrefix(toURL, "/login/") {
-				u, _ := url.Parse(toURL)
-				qs := u.Query()
-				qs.Set("redirect", redirect)
-				u.RawQuery = qs.Encode()
-				http.Redirect(w, r, u.String(), http.StatusSeeOther)
+		if redirect != "" {
+			if u, err := url.Parse(redirect); err == nil && u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/") && !strings.HasPrefix(u.Path, "//") && !strings.Contains(redirect, "\\") {
+				if strings.HasPrefix(toURL, "/login/") {
+					loginURL, _ := url.Parse(toURL)
+					qs := loginURL.Query()
+					qs.Set("redirect", redirect)
+					loginURL.RawQuery = qs.Encode()
+					http.Redirect(w, r, loginURL.String(), http.StatusSeeOther)
+					return
+				}
+				http.Redirect(w, r, redirect, http.StatusSeeOther)
 				return
 			}
-			http.Redirect(w, r, redirect, http.StatusSeeOther)
-			return
 		}
 
 		http.Redirect(w, r, toURL, http.StatusSeeOther)

--- a/cmd/gobookmarks/serve.go
+++ b/cmd/gobookmarks/serve.go
@@ -552,12 +552,14 @@ func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		type Data struct {
 			*gobookmarks.CoreData
-			Error string
+			Error    string
+			Redirect string
 		}
 
 		data := Data{
 			CoreData: r.Context().Value(gobookmarks.ContextValues("coreData")).(*gobookmarks.CoreData),
 			Error:    r.URL.Query().Get("error"),
+			Redirect: r.URL.Query().Get("redirect"),
 		}
 
 		var buf bytes.Buffer
@@ -605,6 +607,30 @@ func runTemplate(tmpl string) func(http.ResponseWriter, *http.Request) {
 
 func redirectToHandler(toURL string) func(http.ResponseWriter, *http.Request) {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirect := r.FormValue("redirect")
+		if session, err := gobookmarks.SessionStore.Get(r, gobookmarks.Config.GetSessionName()); err == nil {
+			if rURL, ok := session.Values["Redirect"].(string); ok && rURL != "" {
+				if redirect == "" {
+					redirect = rURL
+				}
+				delete(session.Values, "Redirect")
+				_ = session.Save(r, w)
+			}
+		}
+
+		if redirect != "" && strings.HasPrefix(redirect, "/") && !strings.HasPrefix(redirect, "//") {
+			if strings.HasPrefix(toURL, "/login/") {
+				u, _ := url.Parse(toURL)
+				qs := u.Query()
+				qs.Set("redirect", redirect)
+				u.RawQuery = qs.Encode()
+				http.Redirect(w, r, u.String(), http.StatusSeeOther)
+				return
+			}
+			http.Redirect(w, r, redirect, http.StatusSeeOther)
+			return
+		}
+
 		http.Redirect(w, r, toURL, http.StatusSeeOther)
 	})
 }

--- a/data_test.go
+++ b/data_test.go
@@ -46,6 +46,7 @@ func testFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"now":                func() time.Time { return time.Unix(0, 0) },
 		"version":            func() string { return "test" },
+		"CurrentURL":         func() string { return "/" },
 		"LoginURL":           func(p string) string { return "https://example.com/login/" + p },
 		"Providers":          func() []string { return []string{"github", "gitlab"} },
 		"AllProviders":       func() []string { return []string{"github", "gitlab"} },

--- a/funcs.go
+++ b/funcs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -68,7 +69,19 @@ func NewFuncs(r *http.Request) template.FuncMap {
 			}
 			return s[:l]
 		},
+		"CurrentURL": func() string {
+			if r != nil {
+				return r.URL.RequestURI()
+			}
+			return ""
+		},
 		"LoginURL": func(p string) string {
+			if r != nil {
+				redirect := r.URL.Query().Get("redirect")
+				if redirect != "" {
+					return "/login/" + p + "?redirect=" + url.QueryEscape(redirect)
+				}
+			}
 			return "/login/" + p
 		},
 		"Providers": func() []string {

--- a/templates/gitLoginPage.gohtml
+++ b/templates/gitLoginPage.gohtml
@@ -1,5 +1,6 @@
 {{ template "head" $ }}
 <form method="POST" action="/login/git">
+    {{- if .Redirect }}<input type="hidden" name="redirect" value="{{ .Redirect }}">{{ end }}
     {{- if .Error }}<p style="color:red">{{ errorMsg .Error }}</p>{{ end }}
     Username: <input type="text" name="username"><br>
     Password: <input type="password" name="password"><br>

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -53,7 +53,7 @@
                                                 </ul>
                                                 {{ end }}
                                         {{ else }}
-                                                <a href="/login">Login</a><br/>
+                                                <a href="/login?redirect={{ CurrentURL | urlquery }}">Login</a><br/>
                                         {{ end }}
                                 <td>
 {{end}}

--- a/templates/mainPage.gohtml
+++ b/templates/mainPage.gohtml
@@ -1,6 +1,6 @@
 {{ template "head" $ }}
     {{ if not loggedIn }}
-        You will need to login to see this page: <a href="/login">Login</a><br>
+        You will need to login to see this page: <a href="/login?redirect={{ CurrentURL | urlquery }}">Login</a><br>
     {{else}}
         {{- if not bookmarksExist }}
         <p>Your bookmarks repository was not found. Click <a href="/edit">here</a> to create it.</p>

--- a/templates/sqlLoginPage.gohtml
+++ b/templates/sqlLoginPage.gohtml
@@ -1,5 +1,6 @@
 {{ template "head" $ }}
 <form method="POST" action="/login/sql">
+    {{- if .Redirect }}<input type="hidden" name="redirect" value="{{ .Redirect }}">{{ end }}
     {{- if .Error }}<p style="color:red">{{ errorMsg .Error }}</p>{{ end }}
     Username: <input type="text" name="username"><br>
     Password: <input type="password" name="password"><br>


### PR DESCRIPTION
Fixes an issue where users are not redirected back to their previous page after logging in. 
The current URL is now captured and passed through the login process, and the server honors it if it's a safe local path.

---
*PR created automatically by Jules for task [6656424172380060602](https://jules.google.com/task/6656424172380060602) started by @arran4*