### PR TITLE
Fix OAuth2 redirect URL corruption during login

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -106,7 +106,8 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	state := providerName
-	if redirect := r.URL.Query().Get("redirect"); redirect != "" {
+	redirect := r.URL.Query().Get("redirect")
+	if redirect != "" && len(redirect) < 2048 {
 		state = providerName + ":" + redirect
 	}
 

--- a/authHandlers.go
+++ b/authHandlers.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/oauth2"
 	"log"
 	"net/http"
+	"strings"
 )
 
 func UserLogoutAction(w http.ResponseWriter, r *http.Request) error {
@@ -103,7 +104,13 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 		http.NotFound(w, r)
 		return nil
 	}
-	http.Redirect(w, r, cfg.AuthCodeURL(providerName), http.StatusTemporaryRedirect)
+
+	state := providerName
+	if redirect := r.URL.Query().Get("redirect"); redirect != "" {
+		state = providerName + ":" + redirect
+	}
+
+	http.Redirect(w, r, cfg.AuthCodeURL(state), http.StatusTemporaryRedirect)
 	return nil
 }
 
@@ -115,7 +122,13 @@ func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	providerName := r.URL.Query().Get("state")
-	if providerName == "" {
+	if providerName != "" {
+		parts := strings.SplitN(providerName, ":", 2)
+		providerName = parts[0]
+		if len(parts) > 1 && parts[1] != "" && len(parts[1]) < 2048 {
+			session.Values["Redirect"] = parts[1]
+		}
+	} else {
 		providerName, _ = session.Values["Provider"].(string)
 	}
 	p := GetProvider(providerName)


### PR DESCRIPTION
Fix OAuth2 redirect URL corruption during login

When navigating to a restricted route requiring login, the system appends the user's current destination directly into the `redirect` query parameter via URL encoding. However, due to standard routing match semantics with Gorilla Mux, any URL-encoded `?` character (`%3F`) present within the target path caused the `providerName` (`mux.Vars(r)["provider"]`) to accidentally encompass the entire redirect URL string (e.g. `github?redirect=/some/path`).

This combined path variable was incorrectly fed raw into `cfg.AuthCodeURL(providerName)` and assigned as the OAuth `state`, leading to an "unknown provider" error on callback (`Oauth2CallbackPage`) when it attempted to load a non-existent provider containing the redirect string.

This fix elegantly splits the state propagation. `LoginWithProvider` cleanly splits the provider name and the redirect string, injecting them both as a combined `providerName:redirect` sequence into the `AuthCodeURL()` `state` object. Upon returning to the `Oauth2CallbackPage`, the callback parses the components, ensures the application cleanly routes against a known provider, and stashes the redirect context downstream back into the `session.Values["Redirect"]` field, successfully restoring the user to their initial pre-login state.

---
*PR created automatically by Jules for task [3147313406664336739](https://jules.google.com/task/3147313406664336739) started by @arran4*