### PR TITLE
Fix: Strip authentication and logout URLs from redirect behavior

### DIFF
--- a/cmd/gobookmarks/serve.go
+++ b/cmd/gobookmarks/serve.go
@@ -620,6 +620,9 @@ func redirectToHandler(toURL string) func(http.ResponseWriter, *http.Request) {
 
 		if redirect != "" {
 			if u, err := url.Parse(redirect); err == nil && u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/") && !strings.HasPrefix(u.Path, "//") && !strings.Contains(redirect, "\\") {
+				if u.Path == "/logout" || u.Path == "/login" || strings.HasPrefix(u.Path, "/login/") {
+					redirect = "/"
+				}
 				if strings.HasPrefix(toURL, "/login/") {
 					loginURL, _ := url.Parse(toURL)
 					qs := loginURL.Query()


### PR DESCRIPTION
When authenticating, if the destination `redirect` URL supplied points to `/logout`, `/login`, or `/login/*`, we want to strip it and default to the site root `/`. This avoids situations where a user successfully authenticates only to be immediately logged back out, or sent to a login screen again.

This change is encapsulated in `redirectToHandler` inside `cmd/gobookmarks/serve.go`.

---
*PR created automatically by Jules for task [9640058818240684840](https://jules.google.com/task/9640058818240684840) started by @arran4*