### PR TITLE
Append tab name to page title

### DIFF
--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -1,7 +1,7 @@
 {{define "head"}}
 <html>
 	<head>
-                <title>{{$.Title}}</title>
+                <title>{{$.Title}}{{ $tname := tabName }}{{ if $tname }}: {{ $tname }}{{ end }}</title>
 		<style type="text/css">
         <!--
         @import url("/main.css");


### PR DESCRIPTION
Appends the current tab name to the HTML title tag if a tab is present.

---
*PR created automatically by Jules for task [15419955320029848543](https://jules.google.com/task/15419955320029848543) started by @arran4*