### PR TITLE
Fix dropping category to a new column

### DIFF
--- a/bookmarkActionHandlers.go
+++ b/bookmarkActionHandlers.go
@@ -235,7 +235,10 @@ func CategoryMoveNewColumnAction(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return fmt.Errorf("invalid from index: %w", err)
 	}
-	destCol, _ := strconv.Atoi(destColStr)
+	destCol, err := strconv.Atoi(destColStr)
+	if destColStr == "" || err != nil {
+		destCol = -1
+	}
 
 	session := r.Context().Value(ContextValues("session")).(*sessions.Session)
 	githubUser, _ := session.Values["GithubUser"].(*User)

--- a/bookmark_model.go
+++ b/bookmark_model.go
@@ -488,7 +488,17 @@ func (b BookmarkList) MoveCategory(fromIndex, toIndex int, newColumn bool, destP
 	}
 
 	if len(src.column.Categories) == 0 && src.column != destColumn {
-		src.block.Columns = append(src.block.Columns[:src.colIdx], src.block.Columns[src.colIdx+1:]...)
+		// Find the current index of the source column, as it may have shifted
+		colIdx := -1
+		for i, col := range src.block.Columns {
+			if col == src.column {
+				colIdx = i
+				break
+			}
+		}
+		if colIdx != -1 {
+			src.block.Columns = append(src.block.Columns[:colIdx], src.block.Columns[colIdx+1:]...)
+		}
 	}
 
 	// reindex


### PR DESCRIPTION
Fixes an issue where dragging and dropping a category card to a new column on the far right would either not move the card or delete the wrong column.

---
*PR created automatically by Jules for task [16872483277423581631](https://jules.google.com/task/16872483277423581631) started by @arran4*