### PR TITLE
Fix: Prevent drag and drop after an action that causes a page refresh

### DIFF
--- a/templates/dragdrop.gohtml
+++ b/templates/dragdrop.gohtml
@@ -7,7 +7,7 @@ function enableDragSort(list, buildUrl) {
         const handle = li.querySelector('.move-handle') || li;
         handle.draggable = true;
         handle.addEventListener('dragstart', e => {
-            if (!document.body.classList.contains('edit-mode')) {
+            if (window.isDragUpdating || !document.body.classList.contains('edit-mode')) {
                 e.preventDefault();
                 return;
             }
@@ -20,11 +20,15 @@ function enableDragSort(list, buildUrl) {
         });
         li.addEventListener('drop', e => {
             e.preventDefault();
+            if (window.isDragUpdating) {
+                return;
+            }
             if (dragEl && dragEl !== li) {
                 const items = Array.from(list.querySelectorAll('li'));
                 const from = items.indexOf(dragEl);
                 const to = items.indexOf(li);
                 if (from >= 0 && to >= 0) {
+                    window.isDragUpdating = true;
                     if (from < to) {
                         li.after(dragEl);
                     } else {

--- a/templates/mainPage.gohtml
+++ b/templates/mainPage.gohtml
@@ -149,6 +149,10 @@
             });
 
             function dragStart(e) {
+                if (window.isDragUpdating) {
+                    e.preventDefault();
+                    return;
+                }
                 var block = e.currentTarget.closest('.categoryBlock');
                 startZone = findColumnZone(block);
                 e.dataTransfer.setData('text/plain', block.id);
@@ -247,9 +251,11 @@
             function drop(e) {
                 e.preventDefault();
                 e.currentTarget.classList.remove('drag-over');
+                if (window.isDragUpdating) return;
                 var id = e.dataTransfer.getData('text/plain');
                 var el = document.getElementById(id);
                 if (el && el !== e.currentTarget) {
+                    window.isDragUpdating = true;
                     e.currentTarget.parentNode.insertBefore(el, e.currentTarget);
                     var from = parseInt(id.substring(3));
                     var to = parseInt(e.currentTarget.id.substring(3));
@@ -267,9 +273,11 @@
             function dropNewColumn(e) {
                 e.preventDefault();
                 e.currentTarget.classList.remove('drag-over');
+                if (window.isDragUpdating) return;
                 var id = e.dataTransfer.getData('text/plain');
                 var el = document.getElementById(id);
                 if (el) {
+                    window.isDragUpdating = true;
                     var from = parseInt(id.substring(3));
                     var pageSha = e.dataTransfer.getData('pageSha');
                     var destPage = e.currentTarget.closest('.bookmarkPage');
@@ -302,9 +310,11 @@
             function dropEndColumn(e) {
                 e.preventDefault();
                 e.currentTarget.classList.remove('drag-over');
+                if (window.isDragUpdating) return;
                 var id = e.dataTransfer.getData('text/plain');
                 var el = document.getElementById(id);
                 if (el) {
+                    window.isDragUpdating = true;
                     var parent = e.currentTarget.parentNode;
                     parent.insertBefore(el, e.currentTarget);
                     var from = parseInt(id.substring(3));
@@ -322,8 +332,10 @@
             function dropOnPageIndex(e) {
                 e.preventDefault();
                 e.currentTarget.classList.remove('drag-over');
+                if (window.isDragUpdating) return;
                 var id = e.dataTransfer.getData('text/plain');
                 if (id) {
+                    window.isDragUpdating = true;
                     var from = parseInt(id.substring(3));
                     var pageSha = e.dataTransfer.getData('pageSha');
                     var destSha = e.currentTarget.dataset.pageSha;
@@ -335,8 +347,10 @@
             function dropOnTabIndex(e) {
                 e.preventDefault();
                 e.currentTarget.classList.remove('drag-over');
+                if (window.isDragUpdating) return;
                 var id = e.dataTransfer.getData('text/plain');
                 if (id) {
+                    window.isDragUpdating = true;
                     var from = parseInt(id.substring(3));
                     var pageSha = e.dataTransfer.getData('pageSha');
                     var destSha = e.currentTarget.dataset.pageSha;


### PR DESCRIPTION
The user requested to prevent dragging and dropping after an action that causes a page refresh. This change adds a `window.isDragUpdating` global variable to both `templates/dragdrop.gohtml` and `templates/mainPage.gohtml`. When a drop action completes, this variable is set to true immediately before sending the `fetch` request to update the backend. Subsequent `dragstart` and `drop` events check this variable and abort immediately if an update is already in progress, effectively blocking further UI interactions until the page reloads.

---
*PR created automatically by Jules for task [11741128595524606557](https://jules.google.com/task/11741128595524606557) started by @arran4*