### PR TITLE
Fix styling for new column drop zone

### DIFF
--- a/main.css
+++ b/main.css
@@ -195,6 +195,20 @@ body:not(.edit-mode) .edit-mode-only {
     margin-left: 0.5em;
 }
 
+.bookmarkColumns .newColumnDropZone:last-child {
+    width: 15em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(128, 0, 0, 0.6);
+}
+
+.bookmarkColumns .newColumnDropZone:last-child::after {
+    content: "Drop here to create a new column";
+    text-align: center;
+    padding: 1em;
+}
+
 .columnEndDropZone {
     width: 100%;
     min-height: 150px;


### PR DESCRIPTION
Fixes the visual presentation of the trailing `.newColumnDropZone` element to have a standard column width and display the helper text "Drop here to create a new column". This provides better usability when drag-and-dropping bookmarks to establish a brand-new column.

---
*PR created automatically by Jules for task [1386270194959981714](https://jules.google.com/task/1386270194959981714) started by @arran4*