### PR TITLE
feat: Optional dependency injection for config loading

### DIFF
--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -135,50 +135,56 @@ func (c *RootCommand) Execute(args []string) error {
 	return nil
 }
 
-func (c *RootCommand) loadConfig() error {
-	envPath := os.Getenv("GOBM_ENV_FILE")
+func (c *RootCommand) loadConfig(ops ...any) error {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	envPath := env.Getenv("GOBM_ENV_FILE")
 	if envPath == "" {
 		envPath = "/etc/gobookmarks/gobookmarks.env"
 	}
-	if err := gobookmarks.LoadEnvFile(envPath); err != nil {
+	if err := gobookmarks.LoadEnvFile(envPath, ops...); err != nil {
 		log.Printf("unable to load env file %s: %v", envPath, err)
 	}
 
 	c.cfg = gobookmarks.Configuration{
-		GithubClientID:       os.Getenv("GITHUB_CLIENT_ID"),
-		GithubSecret:         os.Getenv("GITHUB_SECRET"),
-		GitlabClientID:       os.Getenv("GITLAB_CLIENT_ID"),
-		GitlabSecret:         os.Getenv("GITLAB_SECRET"),
-		ExternalURL:          os.Getenv("EXTERNAL_URL"),
-		CSSColumns:           getenvSet("GBM_CSS_COLUMNS"),
-		DevMode:              getenvBoolPtr("GBM_DEV_MODE"),
-		Namespace:            os.Getenv("GBM_NAMESPACE"),
-		Title:                os.Getenv("GBM_TITLE"),
-		GithubServer:         os.Getenv("GITHUB_SERVER"),
-		GitlabServer:         os.Getenv("GITLAB_SERVER"),
-		FaviconCacheDir:      os.Getenv("FAVICON_CACHE_DIR"),
-		FaviconCacheSize:     getenvInt64("FAVICON_CACHE_SIZE"),
-		FaviconMaxCacheCount: getenvInt("FAVICON_MAX_CACHE_COUNT"),
-		LocalGitPath:         os.Getenv("LOCAL_GIT_PATH"),
-		NoFooter:             getenvBool("GBM_NO_FOOTER"),
-		SessionKey:           os.Getenv("SESSION_KEY"),
-		SessionName:          os.Getenv("SESSION_NAME"),
-		DBConnectionProvider: os.Getenv("DB_CONNECTION_PROVIDER"),
-		DBConnectionString:   os.Getenv("DB_CONNECTION_STRING"),
-		ProviderOrder:        getenvStringSlice("PROVIDER_ORDER"),
-		CommitsPerPage:       getenvInt("COMMITS_PER_PAGE"),
+		GithubClientID:       env.Getenv("GITHUB_CLIENT_ID"),
+		GithubSecret:         env.Getenv("GITHUB_SECRET"),
+		GitlabClientID:       env.Getenv("GITLAB_CLIENT_ID"),
+		GitlabSecret:         env.Getenv("GITLAB_SECRET"),
+		ExternalURL:          env.Getenv("EXTERNAL_URL"),
+		CSSColumns:           getenvSet("GBM_CSS_COLUMNS", ops...),
+		DevMode:              getenvBoolPtr("GBM_DEV_MODE", ops...),
+		Namespace:            env.Getenv("GBM_NAMESPACE"),
+		Title:                env.Getenv("GBM_TITLE"),
+		GithubServer:         env.Getenv("GITHUB_SERVER"),
+		GitlabServer:         env.Getenv("GITLAB_SERVER"),
+		FaviconCacheDir:      env.Getenv("FAVICON_CACHE_DIR"),
+		FaviconCacheSize:     getenvInt64("FAVICON_CACHE_SIZE", ops...),
+		FaviconMaxCacheCount: getenvInt("FAVICON_MAX_CACHE_COUNT", ops...),
+		LocalGitPath:         env.Getenv("LOCAL_GIT_PATH"),
+		NoFooter:             getenvBool("GBM_NO_FOOTER", ops...),
+		SessionKey:           env.Getenv("SESSION_KEY"),
+		SessionName:          env.Getenv("SESSION_NAME"),
+		DBConnectionProvider: env.Getenv("DB_CONNECTION_PROVIDER"),
+		DBConnectionString:   env.Getenv("DB_CONNECTION_STRING"),
+		ProviderOrder:        getenvStringSlice("PROVIDER_ORDER", ops...),
+		CommitsPerPage:       getenvInt("COMMITS_PER_PAGE", ops...),
 	}
 
-	configPath := gobookmarks.DefaultConfigPath()
-	if envCfg := os.Getenv("GOBM_CONFIG_FILE"); envCfg != "" {
+	configPath := gobookmarks.DefaultConfigPath(ops...)
+	if envCfg := env.Getenv("GOBM_CONFIG_FILE"); envCfg != "" {
 		configPath = envCfg
 	}
 	if c.ConfigPath != "" {
 		configPath = c.ConfigPath
 	}
 
-	cfgSpecified := c.ConfigPath != "" || os.Getenv("GOBM_CONFIG_FILE") != ""
-	found, err := gobookmarks.LoadConfigFileInto(&c.cfg, configPath)
+	cfgSpecified := c.ConfigPath != "" || env.Getenv("GOBM_CONFIG_FILE") != ""
+	found, err := gobookmarks.LoadConfigFileInto(&c.cfg, configPath, ops...)
 	if err != nil {
 		return fmt.Errorf("unable to load config file %s: %w", configPath, err)
 	}
@@ -192,13 +198,27 @@ func printHelp(cmd Command, err error) {
 	fmt.Print(renderTemplate(cmd, err))
 }
 
-func getenvSet(key string) bool {
-	val := os.Getenv(key)
+func getenvSet(key string, ops ...any) bool {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	return val != ""
 }
 
-func getenvBool(key string) bool {
-	val := os.Getenv(key)
+func getenvBool(key string, ops ...any) bool {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	if val == "" {
 		return false
 	}
@@ -209,8 +229,15 @@ func getenvBool(key string) bool {
 	return b
 }
 
-func getenvBoolPtr(key string) *bool {
-	val := os.Getenv(key)
+func getenvBoolPtr(key string, ops ...any) *bool {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	if val == "" {
 		return nil
 	}
@@ -222,8 +249,15 @@ func getenvBoolPtr(key string) *bool {
 	return &b
 }
 
-func getenvInt(key string) int {
-	val := os.Getenv(key)
+func getenvInt(key string, ops ...any) int {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	if val == "" {
 		return 0
 	}
@@ -234,8 +268,15 @@ func getenvInt(key string) int {
 	return i
 }
 
-func getenvInt64(key string) int64 {
-	val := os.Getenv(key)
+func getenvInt64(key string, ops ...any) int64 {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	if val == "" {
 		return 0
 	}
@@ -246,8 +287,15 @@ func getenvInt64(key string) int64 {
 	return i
 }
 
-func getenvStringSlice(key string) []string {
-	val := os.Getenv(key)
+func getenvStringSlice(key string, ops ...any) []string {
+	var env gobookmarks.Environment = gobookmarks.DefaultEnvironment{}
+	for _, opt := range ops {
+		if e, ok := opt.(gobookmarks.Environment); ok {
+			env = e
+		}
+	}
+	_ = env
+	val := env.Getenv(key)
 	if val == "" {
 		return nil
 	}

--- a/cmd/gobookmarks/main.go
+++ b/cmd/gobookmarks/main.go
@@ -205,7 +205,6 @@ func getenvSet(key string, ops ...any) bool {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	return val != ""
 }
@@ -217,7 +216,6 @@ func getenvBool(key string, ops ...any) bool {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	if val == "" {
 		return false
@@ -236,7 +234,6 @@ func getenvBoolPtr(key string, ops ...any) *bool {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	if val == "" {
 		return nil
@@ -256,7 +253,6 @@ func getenvInt(key string, ops ...any) int {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	if val == "" {
 		return 0
@@ -275,7 +271,6 @@ func getenvInt64(key string, ops ...any) int64 {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	if val == "" {
 		return 0
@@ -294,7 +289,6 @@ func getenvStringSlice(key string, ops ...any) []string {
 			env = e
 		}
 	}
-	_ = env
 	val := env.Getenv(key)
 	if val == "" {
 		return nil

--- a/cmd/gobookmarks/main_test.go
+++ b/cmd/gobookmarks/main_test.go
@@ -14,6 +14,35 @@ import (
 	"golang.org/x/oauth2"
 )
 
+type MockEnv map[string]string
+
+func (m MockEnv) Getenv(key string) string { return m[key] }
+func (m MockEnv) Setenv(key, value string) error { m[key] = value; return nil }
+func (m MockEnv) Geteuid() int { return 1000 }
+
+type MockFileReader struct {
+	Files map[string][]byte
+}
+
+func (m MockFileReader) ReadFile(name string) ([]byte, error) {
+	if data, ok := m.Files[name]; ok {
+		return data, nil
+	}
+	return nil, os.ErrNotExist
+}
+func (m MockFileReader) Open(name string) (*os.File, error) {
+    // not used deeply here but can return error to avoid failure
+	return nil, os.ErrNotExist
+}
+func (m MockFileReader) Stat(name string) (os.FileInfo, error) {
+	if _, ok := m.Files[name]; ok {
+        // returning nil fileinfo is problematic if accessed, but we just need err == nil for fileExists
+		return nil, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+
 func TestRunHandlerChain_UserErrorRedirect(t *testing.T) {
 	gb.Config.SessionName = "testsess"
 	gb.SessionStore = sessions.NewCookieStore([]byte("secret"))
@@ -71,9 +100,8 @@ func TestRunTemplate_BufferedError(t *testing.T) {
 func TestLoadConfigUsesExternalURL(t *testing.T) {
 	rc := NewRootCommand()
 
-	t.Setenv("EXTERNAL_URL", "http://example.com/app")
-
-	if err := rc.loadConfig(); err != nil {
+	env := MockEnv{"EXTERNAL_URL": "http://example.com/app"}
+	if err := rc.loadConfig(env); err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
 
@@ -83,10 +111,9 @@ func TestLoadConfigUsesExternalURL(t *testing.T) {
 }
 
 func TestLoadConfig_EnvOnlyProvider(t *testing.T) {
-	t.Setenv("LOCAL_GIT_PATH", "/env/path/for/git")
-
 	rc := NewRootCommand()
-	if err := rc.loadConfig(); err != nil {
+	env := MockEnv{"LOCAL_GIT_PATH": "/env/path/for/git"}
+	if err := rc.loadConfig(env); err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
 
@@ -110,24 +137,22 @@ func TestLoadConfig_EnvOnlyProvider(t *testing.T) {
 }
 
 func TestLoadConfig_EnvPrecedence(t *testing.T) {
-	t.Setenv("LOCAL_GIT_PATH", "/env/path")
-	t.Setenv("SESSION_NAME", "env_session")
-	t.Setenv("GBM_CSS_COLUMNS", "0") // Documented contract: any non-empty value sets it to true
-	t.Setenv("GBM_NO_FOOTER", "true")
-	t.Setenv("GBM_DEV_MODE", "false")
-	t.Setenv("COMMITS_PER_PAGE", "50")
-
-	jsonConfig := `{"local_git_path": "/json/path", "css_columns": false, "no_footer": false, "dev_mode": true, "commits_per_page": 0, "session_name": ""}`
-
-	tmpDir := t.TempDir()
-	configPath := tmpDir + "/config.json"
-	if err := os.WriteFile(configPath, []byte(jsonConfig), 0644); err != nil {
-		t.Fatal(err)
+	env := MockEnv{
+		"LOCAL_GIT_PATH": "/env/path",
+		"SESSION_NAME": "env_session",
+		"GBM_CSS_COLUMNS": "0",
+		"GBM_NO_FOOTER": "true",
+		"GBM_DEV_MODE": "false",
+		"COMMITS_PER_PAGE": "50",
 	}
 
+	jsonConfig := `{"local_git_path": "/json/path", "css_columns": false, "no_footer": false, "dev_mode": true, "commits_per_page": 0, "session_name": ""}`
+	fs := MockFileReader{Files: map[string][]byte{"/config.json": []byte(jsonConfig)}}
+	_ = fs
+
 	rc := NewRootCommand()
-	rc.ConfigPath = configPath // JSON config should override env
-	if err := rc.loadConfig(); err != nil {
+	rc.ConfigPath = "/config.json"
+	if err := rc.loadConfig(env, fs); err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
 

--- a/cmd/gobookmarks/main_test.go
+++ b/cmd/gobookmarks/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,34 +15,33 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type MockEnv map[string]string
+type MockEnv struct {
+	Env map[string]string
+	Uid int
+}
 
-func (m MockEnv) Getenv(key string) string { return m[key] }
-func (m MockEnv) Setenv(key, value string) error { m[key] = value; return nil }
-func (m MockEnv) Geteuid() int { return 1000 }
+func (m MockEnv) Getenv(key string) string       { return m.Env[key] }
+func (m MockEnv) Setenv(key, value string) error { m.Env[key] = value; return nil }
+func (m MockEnv) Geteuid() int                   { return m.Uid }
 
 type MockFileReader struct {
 	Files map[string][]byte
 }
 
-func (m MockFileReader) ReadFile(name string) ([]byte, error) {
+func (m *MockFileReader) ReadFile(name string) ([]byte, error) {
 	if data, ok := m.Files[name]; ok {
 		return data, nil
 	}
 	return nil, os.ErrNotExist
 }
-func (m MockFileReader) Open(name string) (*os.File, error) {
-    // not used deeply here but can return error to avoid failure
-	return nil, os.ErrNotExist
-}
-func (m MockFileReader) Stat(name string) (os.FileInfo, error) {
+func (m *MockFileReader) Open(name string) (io.ReadCloser, error) { return nil, os.ErrNotExist }
+func (m *MockFileReader) Stat(name string) (os.FileInfo, error) {
 	if _, ok := m.Files[name]; ok {
-        // returning nil fileinfo is problematic if accessed, but we just need err == nil for fileExists
+		// returning nil fileinfo is problematic if accessed, but we just need err == nil for fileExists
 		return nil, nil
 	}
 	return nil, os.ErrNotExist
 }
-
 
 func TestRunHandlerChain_UserErrorRedirect(t *testing.T) {
 	gb.Config.SessionName = "testsess"
@@ -100,7 +100,7 @@ func TestRunTemplate_BufferedError(t *testing.T) {
 func TestLoadConfigUsesExternalURL(t *testing.T) {
 	rc := NewRootCommand()
 
-	env := MockEnv{"EXTERNAL_URL": "http://example.com/app"}
+	env := MockEnv{Env: map[string]string{"EXTERNAL_URL": "http://example.com/app"}, Uid: 1000}
 	if err := rc.loadConfig(env); err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestLoadConfigUsesExternalURL(t *testing.T) {
 
 func TestLoadConfig_EnvOnlyProvider(t *testing.T) {
 	rc := NewRootCommand()
-	env := MockEnv{"LOCAL_GIT_PATH": "/env/path/for/git"}
+	env := MockEnv{Env: map[string]string{"LOCAL_GIT_PATH": "/env/path/for/git"}, Uid: 1000}
 	if err := rc.loadConfig(env); err != nil {
 		t.Fatalf("loadConfig returned error: %v", err)
 	}
@@ -137,17 +137,17 @@ func TestLoadConfig_EnvOnlyProvider(t *testing.T) {
 }
 
 func TestLoadConfig_EnvPrecedence(t *testing.T) {
-	env := MockEnv{
-		"LOCAL_GIT_PATH": "/env/path",
-		"SESSION_NAME": "env_session",
-		"GBM_CSS_COLUMNS": "0",
-		"GBM_NO_FOOTER": "true",
-		"GBM_DEV_MODE": "false",
+	env := MockEnv{Env: map[string]string{
+		"LOCAL_GIT_PATH":   "/env/path",
+		"SESSION_NAME":     "env_session",
+		"GBM_CSS_COLUMNS":  "0",
+		"GBM_NO_FOOTER":    "true",
+		"GBM_DEV_MODE":     "false",
 		"COMMITS_PER_PAGE": "50",
-	}
+	}, Uid: 1000}
 
 	jsonConfig := `{"local_git_path": "/json/path", "css_columns": false, "no_footer": false, "dev_mode": true, "commits_per_page": 0, "session_name": ""}`
-	fs := MockFileReader{Files: map[string][]byte{"/config.json": []byte(jsonConfig)}}
+	fs := &MockFileReader{Files: map[string][]byte{"/config.json": []byte(jsonConfig)}}
 	_ = fs
 
 	rc := NewRootCommand()
@@ -214,5 +214,54 @@ func TestLoadConfig_EnvPrecedence(t *testing.T) {
 	}
 	if !foundGit {
 		t.Fatalf("expected 'git' provider to be configured since LocalGitPath is set")
+	}
+}
+
+func TestDefaultSessionKeyPath(t *testing.T) {
+	envRoot := MockEnv{Env: map[string]string{"XDG_STATE_HOME": "/xdg_state", "HOME": "/home/root"}, Uid: 0}
+	fsRoot := &MockFileReader{Files: map[string][]byte{"/var/lib/gobookmarks/session.key": []byte("key")}}
+
+	path := gb.DefaultSessionKeyPath(false, envRoot, fsRoot)
+	if path != "/var/lib/gobookmarks/session.key" {
+		t.Errorf("Expected root path to be /var/lib/gobookmarks/session.key, got %s", path)
+	}
+
+	envUser := MockEnv{Env: map[string]string{"XDG_STATE_HOME": "/xdg_state", "HOME": "/home/user"}, Uid: 1000}
+	fsUser := &MockFileReader{Files: map[string][]byte{"/xdg_state/gobookmarks/session.key": []byte("key")}}
+
+	path = gb.DefaultSessionKeyPath(false, envUser, fsUser)
+	if path != "/xdg_state/gobookmarks/session.key" {
+		t.Errorf("Expected user path to be /xdg_state/gobookmarks/session.key, got %s", path)
+	}
+}
+
+func TestLoadEnvFile(t *testing.T) {
+	env := MockEnv{Env: map[string]string{"EXISTING_KEY": "existing_value"}, Uid: 1000}
+
+	envContent := `
+# A comment
+NEW_KEY=new_value
+EXISTING_KEY=overridden_value
+BLANK=
+
+INVALID_LINE
+`
+	fs := &MockFileReader{Files: map[string][]byte{"/test.env": []byte(envContent)}}
+
+	err := gb.LoadEnvFile("/test.env", env, fs)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if env.Env["NEW_KEY"] != "new_value" {
+		t.Errorf("Expected NEW_KEY to be new_value, got %s", env.Env["NEW_KEY"])
+	}
+
+	if env.Env["EXISTING_KEY"] != "existing_value" {
+		t.Errorf("Expected EXISTING_KEY to retain its original value, got %s", env.Env["EXISTING_KEY"])
+	}
+
+	if env.Env["BLANK"] != "" {
+		t.Errorf("Expected BLANK to be empty, got %s", env.Env["BLANK"])
 	}
 }

--- a/config.go
+++ b/config.go
@@ -2,11 +2,13 @@ package gobookmarks
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
-	"errors"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -24,7 +26,6 @@ const (
 	DefaultCommitsPerPage       int           = 100
 )
 
-
 type Environment interface {
 	Getenv(key string) string
 	Setenv(key, value string) error
@@ -33,21 +34,21 @@ type Environment interface {
 
 type DefaultEnvironment struct{}
 
-func (DefaultEnvironment) Getenv(key string) string { return os.Getenv(key) }
+func (DefaultEnvironment) Getenv(key string) string       { return os.Getenv(key) }
 func (DefaultEnvironment) Setenv(key, value string) error { return os.Setenv(key, value) }
-func (DefaultEnvironment) Geteuid() int { return os.Geteuid() }
+func (DefaultEnvironment) Geteuid() int                   { return os.Geteuid() }
 
 type FileReader interface {
 	ReadFile(name string) ([]byte, error)
-	Open(name string) (*os.File, error)
+	Open(name string) (io.ReadCloser, error)
 	Stat(name string) (os.FileInfo, error)
 }
 
 type DefaultFileReader struct{}
 
-func (DefaultFileReader) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
-func (DefaultFileReader) Open(name string) (*os.File, error) { return os.Open(name) }
-func (DefaultFileReader) Stat(name string) (os.FileInfo, error) { return os.Stat(name) }
+func (DefaultFileReader) ReadFile(name string) ([]byte, error)    { return os.ReadFile(name) }
+func (DefaultFileReader) Open(name string) (io.ReadCloser, error) { return os.Open(name) }
+func (DefaultFileReader) Stat(name string) (os.FileInfo, error)   { return os.Stat(name) }
 
 // Configuration holds runtime configuration values.
 type Configuration struct {
@@ -321,21 +322,21 @@ func DefaultSessionKeyPath(writing bool, ops ...any) string {
 
 	if !writing {
 		if env.Geteuid() == 0 {
-			if fileExists(systemPath) {
+			if fileExists(systemPath, ops...) {
 				return systemPath
 			}
 			for _, p := range userPaths {
-				if fileExists(p) {
+				if fileExists(p, ops...) {
 					return p
 				}
 			}
 		} else {
 			for _, p := range userPaths {
-				if fileExists(p) {
+				if fileExists(p, ops...) {
 					return p
 				}
 			}
-			if fileExists(systemPath) {
+			if fileExists(systemPath, ops...) {
 				return systemPath
 			}
 		}
@@ -372,16 +373,15 @@ func LoadEnvFile(path string, ops ...any) error {
 			reader = r
 		}
 	}
-	f, err := reader.Open(path)
+	data, err := reader.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
 	}
-	defer func() { _ = f.Close() }()
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -22,6 +23,31 @@ const (
 	DefaultFaviconCacheMaxAge   time.Duration = 24 * time.Hour
 	DefaultCommitsPerPage       int           = 100
 )
+
+
+type Environment interface {
+	Getenv(key string) string
+	Setenv(key, value string) error
+	Geteuid() int
+}
+
+type DefaultEnvironment struct{}
+
+func (DefaultEnvironment) Getenv(key string) string { return os.Getenv(key) }
+func (DefaultEnvironment) Setenv(key, value string) error { return os.Setenv(key, value) }
+func (DefaultEnvironment) Geteuid() int { return os.Geteuid() }
+
+type FileReader interface {
+	ReadFile(name string) ([]byte, error)
+	Open(name string) (*os.File, error)
+	Stat(name string) (os.FileInfo, error)
+}
+
+type DefaultFileReader struct{}
+
+func (DefaultFileReader) ReadFile(name string) ([]byte, error) { return os.ReadFile(name) }
+func (DefaultFileReader) Open(name string) (*os.File, error) { return os.Open(name) }
+func (DefaultFileReader) Stat(name string) (os.FileInfo, error) { return os.Stat(name) }
 
 // Configuration holds runtime configuration values.
 type Configuration struct {
@@ -86,14 +112,20 @@ func (c Configuration) GetSessionName() string {
 // LoadConfigFile loads configuration from the given path.
 // It returns the loaded Configuration, a boolean indicating if the file existed,
 // and any error that occurred while reading or parsing the file.
-func LoadConfigFile(path string) (Configuration, bool, error) {
+func LoadConfigFile(path string, ops ...any) (Configuration, bool, error) {
+	var reader FileReader = DefaultFileReader{}
+	for _, opt := range ops {
+		if r, ok := opt.(FileReader); ok {
+			reader = r
+		}
+	}
 	var c Configuration
 
 	log.Printf("attempting to load config from %s", path)
 
-	data, err := os.ReadFile(path)
+	data, err := reader.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			log.Printf("config file %s not found", path)
 			return c, false, nil
 		}
@@ -128,12 +160,18 @@ func loadedConfigKeys(c Configuration) []string {
 // LoadConfigFileInto loads configuration from the given path directly onto a struct.
 // It modifies `c` and returns a boolean indicating if the file existed,
 // and any error that occurred while reading or parsing the file.
-func LoadConfigFileInto(c *Configuration, path string) (bool, error) {
+func LoadConfigFileInto(c *Configuration, path string, ops ...any) (bool, error) {
+	var reader FileReader = DefaultFileReader{}
+	for _, opt := range ops {
+		if r, ok := opt.(FileReader); ok {
+			reader = r
+		}
+	}
 	log.Printf("attempting to load config from %s", path)
 
-	data, err := os.ReadFile(path)
+	data, err := reader.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			log.Printf("config file %s not found", path)
 			return false, nil
 		}
@@ -232,16 +270,23 @@ func MergeConfig(dst *Configuration, src Configuration) {
 // environment and the effective user. If running as a non-root user and
 // XDG variables are set, the config lives under the XDG config directory.
 // Otherwise it falls back to /etc/gobookmarks/config.json.
-func DefaultConfigPath() string {
-	if p := os.Getenv("GOBM_CONFIG_FILE"); p != "" {
+func DefaultConfigPath(ops ...any) string {
+	var env Environment = DefaultEnvironment{}
+	for _, opt := range ops {
+		_ = opt // To silence unused warning if empty block
+		if e, ok := opt.(Environment); ok {
+			env = e
+		}
+	}
+	if p := env.Getenv("GOBM_CONFIG_FILE"); p != "" {
 		return p
 	}
-	if os.Geteuid() != 0 {
-		xdg := os.Getenv("XDG_CONFIG_HOME")
+	if env.Geteuid() != 0 {
+		xdg := env.Getenv("XDG_CONFIG_HOME")
 		if xdg != "" {
 			return filepath.Join(xdg, "gobookmarks", "config.json")
 		}
-		if home := os.Getenv("HOME"); home != "" {
+		if home := env.Getenv("HOME"); home != "" {
 			return filepath.Join(home, ".config", "gobookmarks", "config.json")
 		}
 	}
@@ -256,19 +301,26 @@ func DefaultConfigPath() string {
 // chooses the path appropriate for the current user. When reading it
 // checks the usual locations and returns the first existing file,
 // falling back to the writing location if none are found.
-func DefaultSessionKeyPath(writing bool) string {
+func DefaultSessionKeyPath(writing bool, ops ...any) string {
+	var env Environment = DefaultEnvironment{}
+	for _, opt := range ops {
+		_ = opt // To silence unused warning if empty block
+		if e, ok := opt.(Environment); ok {
+			env = e
+		}
+	}
 	var userPaths []string
-	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+	if xdg := env.Getenv("XDG_STATE_HOME"); xdg != "" {
 		userPaths = append(userPaths, filepath.Join(xdg, "gobookmarks", "session.key"))
 	}
-	if home := os.Getenv("HOME"); home != "" {
+	if home := env.Getenv("HOME"); home != "" {
 		userPaths = append(userPaths, filepath.Join(home, ".local", "state", "gobookmarks", "session.key"))
 	}
 
 	systemPath := "/var/lib/gobookmarks/session.key"
 
 	if !writing {
-		if os.Geteuid() == 0 {
+		if env.Geteuid() == 0 {
 			if fileExists(systemPath) {
 				return systemPath
 			}
@@ -289,7 +341,7 @@ func DefaultSessionKeyPath(writing bool) string {
 		}
 	}
 
-	if os.Geteuid() != 0 {
+	if env.Geteuid() != 0 {
 		if len(userPaths) > 0 {
 			return userPaths[0]
 		}
@@ -297,16 +349,32 @@ func DefaultSessionKeyPath(writing bool) string {
 	return systemPath
 }
 
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
+func fileExists(path string, ops ...any) bool {
+	var reader FileReader = DefaultFileReader{}
+	for _, opt := range ops {
+		if r, ok := opt.(FileReader); ok {
+			reader = r
+		}
+	}
+	_, err := reader.Stat(path)
 	return err == nil
 }
 
 // Lines should be in KEY=VALUE format and may be commented with '#'.
-func LoadEnvFile(path string) error {
-	f, err := os.Open(path)
+func LoadEnvFile(path string, ops ...any) error {
+	var env Environment = DefaultEnvironment{}
+	var reader FileReader = DefaultFileReader{}
+	for _, opt := range ops {
+		if e, ok := opt.(Environment); ok {
+			env = e
+		}
+		if r, ok := opt.(FileReader); ok {
+			reader = r
+		}
+	}
+	f, err := reader.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
@@ -325,8 +393,8 @@ func LoadEnvFile(path string) error {
 		}
 		key := strings.TrimSpace(parts[0])
 		val := strings.TrimSpace(parts[1])
-		if os.Getenv(key) == "" {
-			_ = os.Setenv(key, val)
+		if env.Getenv(key) == "" {
+			_ = env.Setenv(key, val)
 		}
 	}
 	return scanner.Err()


### PR DESCRIPTION
Implemented the requested "Optional Dependency Injection via Type-Switched Variadic Args" pattern to allow configuration overrides during testing without modifying global OS state (like `os.Environ()` or the file system). Tests in `main_test.go` now use `MockEnv` and `MockFileReader`.

---
*PR created automatically by Jules for task [1515795568184609475](https://jules.google.com/task/1515795568184609475) started by @arran4*