### PR TITLE
feat: add manual theme toggle

### DIFF
--- a/main.css
+++ b/main.css
@@ -328,3 +328,22 @@ input.search-widget {
 #page-list li.active-page a {
     font-weight: bold;
 }
+
+.theme-btn {
+    background: none;
+    border: none;
+    color: var(--link-color);
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 0;
+    font: inherit;
+}
+.theme-btn:hover {
+    color: var(--link-hover-color);
+}
+.theme-btn[aria-pressed="true"] {
+    font-weight: bold;
+    color: var(--text-color);
+    text-decoration: none;
+    cursor: default;
+}

--- a/main.css
+++ b/main.css
@@ -8,8 +8,18 @@
     --search-selected-bg: #ffe0e0;
 }
 
+:root[data-theme="dark"] {
+    --bg-color: #121212;
+    --text-color: #ffcccc;
+    --link-color: #cccc66;
+    --link-hover-color: #ff6666;
+    --border-color: rgba(230, 179, 179, 0.6);
+    --dropzone-text-color: rgba(230, 179, 179, 0.6);
+    --search-selected-bg: #4a0000;
+}
+
 @media (prefers-color-scheme: dark) {
-    :root {
+    :root:not([data-theme="light"]) {
         --bg-color: #121212;
         --text-color: #ffcccc;
         --link-color: #cccc66;

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -13,6 +13,16 @@
         </head>
         <body{{if tab}} data-tab="{{tab}}"{{end}}>
                 <script>
+                (function() {
+                    var theme = localStorage.getItem("theme");
+                    if (!theme) {
+                        var match = document.cookie.match(/(?:^|; )theme=([^;]+)/);
+                        if (match) theme = match[1];
+                    }
+                    if (theme === "dark" || theme === "light") {
+                        document.documentElement.setAttribute("data-theme", theme);
+                    }
+                })();
                 if (localStorage.getItem('edit-mode') === '1') {
                     document.body.classList.add('edit-mode');
                 }

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -15,10 +15,6 @@
                 <script>
                 (function() {
                     var theme = localStorage.getItem("theme");
-                    if (!theme) {
-                        var match = document.cookie.match(/(?:^|; )theme=([^;]+)/);
-                        if (match) theme = match[1];
-                    }
                     if (theme === "dark" || theme === "light") {
                         document.documentElement.setAttribute("data-theme", theme);
                     }

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -11,30 +11,42 @@
                                        <a href="https://github.com/arran4/gobookmarks">gobookmarks</a> v{{ version }}<br>
                                        commit {{ commitShort }}<br>
                                        built at {{ buildDate }}
-                                       <br><a href="/status">Status</a><br><a href="#" id="theme-toggle">switch to auto; or toggle lighting mode</a>
+                                       <br><a href="/status">Status</a><br>Theme: <button class="theme-btn" data-theme-target="auto">Auto</button> | <button class="theme-btn" data-theme-target="light">Light</button> | <button class="theme-btn" data-theme-target="dark">Dark</button>
                                </i>
                        </div>
 </footer>
                 {{ end }}
                 <script>
                 document.addEventListener('DOMContentLoaded', function () {
-                    var themeToggle = document.getElementById('theme-toggle');
-                    if (themeToggle) {
-                        themeToggle.addEventListener('click', function(e) {
-                            e.preventDefault();
-                            var currentTheme = document.documentElement.getAttribute('data-theme') || localStorage.getItem('theme');
-                            var newTheme = currentTheme === 'dark' ? 'light' : (currentTheme === 'light' ? '' : 'dark');
-                            if (newTheme) {
-                                document.documentElement.setAttribute('data-theme', newTheme);
-                                localStorage.setItem('theme', newTheme);
-                                document.cookie = "theme=" + newTheme + "; path=/; max-age=31536000";
+                    // Clean up old cookie
+                    document.cookie = "theme=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+
+                    var themeBtns = document.querySelectorAll('.theme-btn');
+                    function updateThemeButtons() {
+                        var currentTheme = document.documentElement.getAttribute('data-theme') || 'auto';
+                        themeBtns.forEach(function(btn) {
+                            if (btn.getAttribute('data-theme-target') === currentTheme) {
+                                btn.setAttribute('aria-pressed', 'true');
                             } else {
-                                document.documentElement.removeAttribute('data-theme');
-                                localStorage.removeItem('theme');
-                                document.cookie = "theme=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+                                btn.setAttribute('aria-pressed', 'false');
                             }
                         });
                     }
+                    updateThemeButtons();
+
+                    themeBtns.forEach(function(btn) {
+                        btn.addEventListener('click', function(e) {
+                            var target = btn.getAttribute('data-theme-target');
+                            if (target === 'auto') {
+                                document.documentElement.removeAttribute('data-theme');
+                                localStorage.removeItem('theme');
+                            } else {
+                                document.documentElement.setAttribute('data-theme', target);
+                                localStorage.setItem('theme', target);
+                            }
+                            updateThemeButtons();
+                        });
+                    });
                 });
                 document.addEventListener('DOMContentLoaded', function () {
                     var editModal = document.getElementById('edit-modal');

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -11,12 +11,31 @@
                                        <a href="https://github.com/arran4/gobookmarks">gobookmarks</a> v{{ version }}<br>
                                        commit {{ commitShort }}<br>
                                        built at {{ buildDate }}
-                                       <br><a href="/status">Status</a>
+                                       <br><a href="/status">Status</a><br><a href="#" id="theme-toggle">switch to auto; or toggle lighting mode</a>
                                </i>
                        </div>
 </footer>
                 {{ end }}
                 <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                    var themeToggle = document.getElementById('theme-toggle');
+                    if (themeToggle) {
+                        themeToggle.addEventListener('click', function(e) {
+                            e.preventDefault();
+                            var currentTheme = document.documentElement.getAttribute('data-theme') || localStorage.getItem('theme');
+                            var newTheme = currentTheme === 'dark' ? 'light' : (currentTheme === 'light' ? '' : 'dark');
+                            if (newTheme) {
+                                document.documentElement.setAttribute('data-theme', newTheme);
+                                localStorage.setItem('theme', newTheme);
+                                document.cookie = "theme=" + newTheme + "; path=/; max-age=31536000";
+                            } else {
+                                document.documentElement.removeAttribute('data-theme');
+                                localStorage.removeItem('theme');
+                                document.cookie = "theme=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+                            }
+                        });
+                    }
+                });
                 document.addEventListener('DOMContentLoaded', function () {
                     var editModal = document.getElementById('edit-modal');
                     var editModalContent = document.getElementById('edit-modal-content');


### PR DESCRIPTION
Added a link in the footer that cycles between auto, light, and dark modes. Modifies the page's styling accordingly by storing preferences locally.

---
*PR created automatically by Jules for task [6566575591969094408](https://jules.google.com/task/6566575591969094408) started by @arran4*