### PR TITLE
fix: restore bookmark column layout by default

### DIFF
--- a/main.css
+++ b/main.css
@@ -160,19 +160,19 @@ body:not(.edit-mode) .edit-mode-only {
 }
 
 
-.cssColumns .bookmarkColumns {
+.bookmarkColumns {
         display: flex;
         flex-wrap: wrap;
         align-items: flex-start;
 }
 
-.cssColumns .bookmarkColumn {
+.bookmarkColumn {
         padding-right: 1em;
         display: flex;
         flex-direction: column;
 }
 
-.cssColumns .categoryBlock {
+.categoryBlock {
         break-inside: avoid;
         page-break-inside: avoid;
         -webkit-column-break-inside: avoid;

--- a/main_css_test.go
+++ b/main_css_test.go
@@ -1,0 +1,20 @@
+package gobookmarks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBookmarkColumnsLayoutDoesNotDependOnCSSColumnsClass(t *testing.T) {
+	css := string(GetMainCSSData())
+
+	if strings.Contains(css, ".cssColumns .bookmarkColumns") {
+		t.Fatal("bookmark column layout must not depend on the optional cssColumns class")
+	}
+	if !strings.Contains(css, ".bookmarkColumns {\n        display: flex;") {
+		t.Fatal("bookmarkColumns must use flex layout by default")
+	}
+	if !strings.Contains(css, ".bookmarkColumn {\n        padding-right: 1em;\n        display: flex;") {
+		t.Fatal("bookmarkColumn must retain its column flex layout by default")
+	}
+}


### PR DESCRIPTION
PR #238 made the flex-based bookmark column layout conditional on the `cssColumns` class. Existing/default deployments can render without that class, causing structured `Column` data to stack vertically instead of appearing as columns.

This change makes the column layout CSS apply directly to `.bookmarkColumns`, `.bookmarkColumn`, and `.categoryBlock`, so rendering structured columns no longer depends on the optional page class.

It also adds a regression test that guards the default flex layout and prevents reintroducing the `.cssColumns .bookmarkColumns` dependency.

Regression introduced by #238.

Testing:
- Added `TestBookmarkColumnsLayoutDoesNotDependOnCSSColumnsClass`.
- CI should run the normal Go test suite.
