### PR TITLE
feat: fingerprint static assets

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,145 @@
+package gobookmarks
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Asset struct {
+	Bytes []byte
+	ETag  string
+}
+
+type Registry struct {
+	mu           sync.RWMutex
+	logicalToURL map[string]string
+	urlToAsset   map[string]*Asset
+	fsys         fs.FS
+}
+
+func NewRegistry(fsys fs.FS) (*Registry, error) {
+	reg := &Registry{
+		logicalToURL: make(map[string]string),
+		urlToAsset:   make(map[string]*Asset),
+		fsys:         fsys,
+	}
+
+	err := reg.Reload()
+	return reg, err
+}
+
+func (r *Registry) Reload() error {
+	if r.fsys == nil {
+		return nil
+	}
+	logicalToURL := make(map[string]string)
+	urlToAsset := make(map[string]*Asset)
+
+	err := fs.WalkDir(r.fsys, ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p == "." {
+				return nil
+			}
+			name := d.Name()
+			if strings.HasPrefix(name, ".") || name == "localgit" || name == "testdata" || name == "sql" || name == "templates" || name == "packaging" || name == "cmd" || name == "media" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		b, err := fs.ReadFile(r.fsys, p)
+		if err != nil {
+			return err
+		}
+
+		// Calculate full SHA-256 digest
+		sum := sha256.Sum256(b)
+		fullDigest := hex.EncodeToString(sum[:])
+
+		fingerprint := fullDigest
+
+		// Insert fingerprint before extension (e.g., css/main.a1b2c3d4....css)
+		ext := path.Ext(p)
+		base := strings.TrimSuffix(p, ext)
+		fingerprintedURL := fmt.Sprintf("/assets/%s.%s%s", base, fingerprint, ext)
+
+		logicalToURL[p] = fingerprintedURL
+		cleanLogical := strings.TrimPrefix(p, "./")
+		logicalToURL[cleanLogical] = fingerprintedURL
+
+		urlToAsset[fingerprintedURL] = &Asset{
+			Bytes: b,
+			ETag:  fmt.Sprintf(`"%s"`, fullDigest),
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.logicalToURL = logicalToURL
+	r.urlToAsset = urlToAsset
+	r.mu.Unlock()
+
+	return nil
+}
+
+func (r *Registry) AssetURL(logicalName string) (string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	cleaned := strings.TrimPrefix(logicalName, "/")
+	cleaned = strings.TrimPrefix(cleaned, "./")
+	if url, ok := r.logicalToURL[cleaned]; ok {
+		return url, nil
+	}
+	if url, ok := r.logicalToURL[logicalName]; ok {
+		return url, nil
+	}
+	return "", fmt.Errorf("asset not found: %s", logicalName)
+}
+
+func (r *Registry) GetAsset(url string) (*Asset, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	a, ok := r.urlToAsset[url]
+	return a, ok
+}
+
+func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	asset, ok := r.GetAsset(req.URL.Path)
+	if !ok {
+		http.NotFound(w, req)
+		return
+	}
+
+	// Set caching headers for immutable fingerprinted asset
+	w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+	w.Header().Set("ETag", asset.ETag)
+
+	// Since these are embedded assets, we might not have a real ModTime.
+	// We pass time.Time{} and let ETag handle validation.
+	http.ServeContent(w, req, req.URL.Path, time.Time{}, bytes.NewReader(asset.Bytes))
+}
+
+func AssetURL(logicalName string) (string, error) {
+	reg := GetAssetRegistry()
+	if reg == nil {
+		return "", fmt.Errorf("asset registry not initialized")
+	}
+	return reg.AssetURL(logicalName)
+}

--- a/assets_test.go
+++ b/assets_test.go
@@ -1,0 +1,119 @@
+package gobookmarks
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+)
+
+func TestAssetRegistry(t *testing.T) {
+	cssContent := []byte("body { background: #fff; }")
+	pngContent := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+	mockFS := fstest.MapFS{
+		"main.css": &fstest.MapFile{Data: cssContent},
+		"logo.png": &fstest.MapFile{Data: pngContent},
+	}
+
+	reg, err := NewRegistry(mockFS)
+	if err != nil {
+		t.Fatalf("NewRegistry failed: %v", err)
+	}
+
+	cssHash := sha256.Sum256(cssContent)
+	cssHex := hex.EncodeToString(cssHash[:])
+	expectedCSSURL := "/assets/main." + cssHex + ".css"
+
+	pngHash := sha256.Sum256(pngContent)
+	pngHex := hex.EncodeToString(pngHash[:])
+	expectedPNGURL := "/assets/logo." + pngHex + ".png"
+
+	url, err := reg.AssetURL("main.css")
+	if err != nil {
+		t.Fatalf("AssetURL(main.css) failed: %v", err)
+	}
+	if url != expectedCSSURL {
+		t.Errorf("expected %s, got %s", expectedCSSURL, url)
+	}
+
+	url, err = reg.AssetURL("/main.css")
+	if err != nil {
+		t.Fatalf("AssetURL(/main.css) failed: %v", err)
+	}
+	if url != expectedCSSURL {
+		t.Errorf("expected %s, got %s", expectedCSSURL, url)
+	}
+
+	url, err = reg.AssetURL("logo.png")
+	if err != nil {
+		t.Fatalf("AssetURL(logo.png) failed: %v", err)
+	}
+	if url != expectedPNGURL {
+		t.Errorf("expected %s, got %s", expectedPNGURL, url)
+	}
+
+	// Unknown asset should fail
+	_, err = reg.AssetURL("unknown.js")
+	if err == nil {
+		t.Errorf("expected error for unknown asset, got nil")
+	}
+
+	// Test ServeHTTP - 200 OK with caching headers
+	req := httptest.NewRequest("GET", expectedCSSURL, nil)
+	rec := httptest.NewRecorder()
+	reg.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=31536000, immutable" {
+		t.Errorf("expected Cache-Control header 'public, max-age=31536000, immutable', got '%s'", cc)
+	}
+	expectedETag := `"` + cssHex + `"`
+	if etag := rec.Header().Get("ETag"); etag != expectedETag {
+		t.Errorf("expected ETag '%s', got '%s'", expectedETag, etag)
+	}
+	if body := rec.Body.String(); body != string(cssContent) {
+		t.Errorf("expected body '%s', got '%s'", string(cssContent), body)
+	}
+
+	// Test Conditional Request - 304 Not Modified
+	req304 := httptest.NewRequest("GET", expectedCSSURL, nil)
+	req304.Header.Set("If-None-Match", expectedETag)
+	rec304 := httptest.NewRecorder()
+	reg.ServeHTTP(rec304, req304)
+
+	if rec304.Code != http.StatusNotModified {
+		t.Errorf("expected status 304 for conditional request, got %d", rec304.Code)
+	}
+
+	// Test 404 Not Found
+	req404 := httptest.NewRequest("GET", "/assets/non-existent.css", nil)
+	rec404 := httptest.NewRecorder()
+	reg.ServeHTTP(rec404, req404)
+
+	if rec404.Code != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", rec404.Code)
+	}
+}
+
+func TestGlobalAssetRegistry(t *testing.T) {
+	cssURL, err := AssetURL("main.css")
+	if err != nil {
+		t.Fatalf("AssetURL(main.css) failed: %v", err)
+	}
+	if cssURL == "" || cssURL == "/main.css" {
+		t.Errorf("expected fingerprinted asset URL, got %s", cssURL)
+	}
+
+	logoURL, err := AssetURL("logo.png")
+	if err != nil {
+		t.Fatalf("AssetURL(logo.png) failed: %v", err)
+	}
+	if logoURL == "" || logoURL == "/logo.png" {
+		t.Errorf("expected fingerprinted asset URL, got %s", logoURL)
+	}
+}

--- a/cmd/gobookmarks/serve.go
+++ b/cmd/gobookmarks/serve.go
@@ -231,10 +231,22 @@ func (c *ServeCommand) Execute(args []string) error {
 	r.Use(gobookmarks.UserAdderMiddleware)
 	r.Use(gobookmarks.CoreAdderMiddleware)
 
-	r.HandleFunc("/main.css", func(writer http.ResponseWriter, _ *http.Request) {
+	r.PathPrefix("/assets/").Handler(gobookmarks.GetAssetRegistry()).Methods("GET")
+
+	r.HandleFunc("/main.css", func(writer http.ResponseWriter, req *http.Request) {
+		if url, err := gobookmarks.AssetURL("main.css"); err == nil {
+			http.Redirect(writer, req, url, http.StatusFound)
+			return
+		}
+		writer.Header().Set("Content-Type", "text/css")
 		_, _ = writer.Write(gobookmarks.GetMainCSSData())
 	}).Methods("GET")
-	r.HandleFunc("/favicon.ico", func(writer http.ResponseWriter, _ *http.Request) {
+	r.HandleFunc("/favicon.ico", func(writer http.ResponseWriter, req *http.Request) {
+		if url, err := gobookmarks.AssetURL("logo.png"); err == nil {
+			http.Redirect(writer, req, url, http.StatusFound)
+			return
+		}
+		writer.Header().Set("Content-Type", "image/png")
 		_, _ = writer.Write(gobookmarks.GetFavicon())
 	}).Methods("GET")
 

--- a/cmd/gobookmarks/test_verification_template_command.go
+++ b/cmd/gobookmarks/test_verification_template_command.go
@@ -291,15 +291,25 @@ https://example.com Example Link
 
 		// For serving, we need to handle main.css and favicon too, otherwise the page looks broken
 		mux := http.NewServeMux()
+		mux.Handle("/assets/", gobookmarks.GetAssetRegistry())
 		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write(output)
 		})
 		mux.HandleFunc("/main.css", func(w http.ResponseWriter, r *http.Request) {
+			if url, err := gobookmarks.AssetURL("main.css"); err == nil {
+				http.Redirect(w, r, url, http.StatusFound)
+				return
+			}
 			w.Header().Set("Content-Type", "text/css")
 			_, _ = w.Write(
 				gobookmarks.GetMainCSSData())
 		})
 		mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+			if url, err := gobookmarks.AssetURL("logo.png"); err == nil {
+				http.Redirect(w, r, url, http.StatusFound)
+				return
+			}
+			w.Header().Set("Content-Type", "image/png")
 			_, _ = w.Write(
 				gobookmarks.GetFavicon())
 		})

--- a/data_embedded.go
+++ b/data_embedded.go
@@ -11,6 +11,8 @@ import (
 var (
 	//go:embed all:templates
 	templateFS embed.FS
+	//go:embed "main.css" "logo.png"
+	assetFS embed.FS
 	//go:embed "main.css"
 	mainCSSData []byte
 	//go:embed "logo.png"
@@ -18,7 +20,21 @@ var (
 
 	compiledTemplates *template.Template
 	compileOnce       sync.Once
+
+	assetRegistry     *Registry
+	assetRegistryOnce sync.Once
 )
+
+func GetAssetRegistry() *Registry {
+	assetRegistryOnce.Do(func() {
+		var err error
+		assetRegistry, err = NewRegistry(assetFS)
+		if err != nil {
+			panic(err)
+		}
+	})
+	return assetRegistry
+}
 
 // GetCompiledTemplates returns a clone of the compiled templates with the given funcs applied.
 // The templates are parsed only once at initialization using NewFuncs(nil) to establish the function map keys.

--- a/data_live.go
+++ b/data_live.go
@@ -7,10 +7,39 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 func init() {
 	log.Printf("Live data mode")
+}
+
+var (
+	assetRegistry     *Registry
+	assetRegistryOnce sync.Once
+)
+
+func getAssetDir() string {
+	fsPath := "."
+	if _, err := os.Stat(filepath.Join(fsPath, "main.css")); os.IsNotExist(err) {
+		fsPath = "../../"
+	}
+	if _, err := os.Stat(filepath.Join(fsPath, "main.css")); os.IsNotExist(err) {
+		fsPath = "../"
+	}
+	return fsPath
+}
+
+func GetAssetRegistry() *Registry {
+	assetRegistryOnce.Do(func() {
+		dir := getAssetDir()
+		var err error
+		assetRegistry, err = NewRegistry(os.DirFS(dir))
+		if err != nil {
+			log.Printf("Asset registry error: %v", err)
+		}
+	})
+	return assetRegistry
 }
 
 func GetCompiledTemplates(funcs template.FuncMap) *template.Template {

--- a/data_test.go
+++ b/data_test.go
@@ -45,6 +45,8 @@ func TestCompileGoHTML(t *testing.T) {
 func testFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"now":                func() time.Time { return time.Unix(0, 0) },
+		"asset":              func(p string) (string, error) { return AssetURL(p) },
+		"assetURL":           func(p string) (string, error) { return AssetURL(p) },
 		"version":            func() string { return "test" },
 		"CurrentURL":         func() string { return "/" },
 		"LoginPageURL":       func() string { return "https://example.com/login" },

--- a/funcs.go
+++ b/funcs.go
@@ -45,6 +45,12 @@ func SetVersion(pVersion, pCommit, pDate string) {
 func NewFuncs(r *http.Request) template.FuncMap {
 	return map[string]any{
 		"now": func() time.Time { return time.Now() },
+		"asset": func(p string) (string, error) {
+			return AssetURL(p)
+		},
+		"assetURL": func(p string) (string, error) {
+			return AssetURL(p)
+		},
 		"version": func() string {
 			return version
 		},

--- a/templates/error.gohtml
+++ b/templates/error.gohtml
@@ -2,7 +2,8 @@
 <html>
 <head>
     <title>Error</title>
-    <link rel="stylesheet" type="text/css" href="/main.css">
+    <link rel="stylesheet" type="text/css" href="{{ asset "main.css" }}">
+    <link rel="icon" type="image/png" href="{{ asset "logo.png" }}">
 </head>
 <body>
     <table border=0 id="layout">

--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -4,9 +4,10 @@
                 <title>{{$.Title}}{{ $tname := tabName }}{{ if $tname }}: {{ $tname }}{{ end }}</title>
 		<style type="text/css">
         <!--
-        @import url("/main.css");
+        @import url("{{ asset "main.css" }}");
         -->
         </style>
+        <link rel="icon" type="image/png" href="{{ asset "logo.png" }}">
         {{ if $.AutoRefresh }}
             <meta http-equiv="refresh" content="1">
         {{ end }}


### PR DESCRIPTION
Implements content-addressed static asset URLs for gobookmarks.

Changes:
- add an asset registry that computes SHA-256 fingerprints and resolves logical asset names to `/assets/<name>.<hash>.<ext>` URLs;
- serve fingerprinted assets with long-lived immutable cache headers and ETags;
- update templates to reference fingerprinted `main.css` and `logo.png` URLs;
- preserve `/main.css` and `/favicon.ico` as compatibility redirects/fallbacks;
- support embedded production assets and live-mode filesystem assets;
- add registry, conditional-request, template, and integration coverage.

This follows the content-hashed asset pattern documented in the project reference article on asset fingerprinting and is intended to prevent deployments from pairing fresh HTML with stale cached CSS.

Testing:
- branch includes unit tests for asset URL generation, strict 404 behavior, cache headers, ETags, and `If-None-Match` handling;
- normal CI should run `go test ./...` and the repository's existing checks.
