### PR TITLE
Fix redirect preservation on auth handlers

### DIFF
--- a/authHandlers.go
+++ b/authHandlers.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"net/url"
 )
 
 func UserLogoutAction(w http.ResponseWriter, r *http.Request) error {
@@ -103,12 +104,12 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 	creds := providerCreds(providerName)
 	if creds == nil {
 		http.NotFound(w, r)
-		return nil
+		return ErrHandled
 	}
 	cfg := p.Config(creds.ID, creds.Secret, Config.GetOauthRedirectURL())
 	if cfg == nil {
 		http.NotFound(w, r)
-		return nil
+		return ErrHandled
 	}
 
 	state := providerName
@@ -117,7 +118,7 @@ func LoginWithProvider(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	http.Redirect(w, r, cfg.AuthCodeURL(state), http.StatusTemporaryRedirect)
-	return nil
+	return ErrHandled
 }
 
 func Oauth2CallbackPage(w http.ResponseWriter, r *http.Request) error {
@@ -217,13 +218,21 @@ func GitLoginAction(w http.ResponseWriter, r *http.Request) error {
 		if !okPass {
 			log.Printf("git login failed for %s: invalid password", user)
 		}
-		http.Redirect(w, r, "/login/git?error=invalid", http.StatusSeeOther)
-		return nil
+		redirectURL := "/login/git?error=invalid"
+		if r.FormValue("redirect") != "" {
+			redirectURL += "&redirect=" + url.QueryEscape(r.FormValue("redirect"))
+		}
+		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+		return ErrHandled
 	}
 	session.Values["Provider"] = "git"
 	session.Values["GithubUser"] = &User{Login: user}
 	session.Values["Token"] = nil
 	session.Values["version"] = version
+	redirect := r.FormValue("redirect")
+	if redirect != "" && len(redirect) < 2048 {
+		session.Values["Redirect"] = redirect
+	}
 	if err := session.Save(r, w); err != nil {
 		return fmt.Errorf("session save: %w", err)
 	}
@@ -241,8 +250,12 @@ func GitSignupAction(w http.ResponseWriter, r *http.Request) error {
 	if err := ph.CreateUser(r.Context(), user, pass); err != nil {
 		if errors.Is(err, ErrUserExists) {
 			log.Printf("git signup for %s failed: user exists", user)
-			http.Redirect(w, r, "/login/git?error=exists", http.StatusSeeOther)
-			return nil
+			redirectURL := "/login/git?error=exists"
+			if r.FormValue("redirect") != "" {
+				redirectURL += "&redirect=" + url.QueryEscape(r.FormValue("redirect"))
+			}
+			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+			return ErrHandled
 		}
 		log.Printf("git signup create user error for %s: %v", user, err)
 		return err
@@ -261,7 +274,12 @@ func GitSignupAction(w http.ResponseWriter, r *http.Request) error {
 		log.Printf("git signup create sample bookmarks error for %s: %v", user, err)
 		return fmt.Errorf("create sample bookmarks: %w", err)
 	}
-	return nil
+	redirectURL := "/login/git"
+	if r.FormValue("redirect") != "" {
+		redirectURL += "?redirect=" + url.QueryEscape(r.FormValue("redirect"))
+	}
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+	return ErrHandled
 }
 
 func SqlLoginAction(w http.ResponseWriter, r *http.Request) error {
@@ -284,13 +302,21 @@ func SqlLoginAction(w http.ResponseWriter, r *http.Request) error {
 		if !okPass {
 			log.Printf("sql login failed for %s: invalid password", user)
 		}
-		http.Redirect(w, r, "/login/sql?error=invalid", http.StatusSeeOther)
-		return nil
+		redirectURL := "/login/sql?error=invalid"
+		if r.FormValue("redirect") != "" {
+			redirectURL += "&redirect=" + url.QueryEscape(r.FormValue("redirect"))
+		}
+		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+		return ErrHandled
 	}
 	session.Values["Provider"] = "sql"
 	session.Values["GithubUser"] = &User{Login: user}
 	session.Values["Token"] = nil
 	session.Values["version"] = version
+	redirect := r.FormValue("redirect")
+	if redirect != "" && len(redirect) < 2048 {
+		session.Values["Redirect"] = redirect
+	}
 	if err := session.Save(r, w); err != nil {
 		return fmt.Errorf("session save: %w", err)
 	}
@@ -308,8 +334,12 @@ func SqlSignupAction(w http.ResponseWriter, r *http.Request) error {
 	if err := ph.CreateUser(r.Context(), user, pass); err != nil {
 		if errors.Is(err, ErrUserExists) {
 			log.Printf("sql signup for %s failed: user exists", user)
-			http.Redirect(w, r, "/login/sql?error=exists", http.StatusSeeOther)
-			return nil
+			redirectURL := "/login/sql?error=exists"
+			if r.FormValue("redirect") != "" {
+				redirectURL += "&redirect=" + url.QueryEscape(r.FormValue("redirect"))
+			}
+			http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+			return ErrHandled
 		}
 		log.Printf("sql signup create user error for %s: %v", user, err)
 		return err
@@ -328,7 +358,12 @@ func SqlSignupAction(w http.ResponseWriter, r *http.Request) error {
 		log.Printf("sql signup create sample bookmarks error for %s: %v", user, err)
 		return fmt.Errorf("create sample bookmarks: %w", err)
 	}
-	return nil
+	redirectURL := "/login/sql"
+	if r.FormValue("redirect") != "" {
+		redirectURL += "?redirect=" + url.QueryEscape(r.FormValue("redirect"))
+	}
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+	return ErrHandled
 }
 
 func UserAdderMiddleware(next http.Handler) http.Handler {

--- a/authHandlers.go
+++ b/authHandlers.go
@@ -9,8 +9,8 @@ import (
 	"golang.org/x/oauth2"
 	"log"
 	"net/http"
-	"strings"
 	"net/url"
+	"strings"
 )
 
 func UserLogoutAction(w http.ResponseWriter, r *http.Request) error {
@@ -230,6 +230,7 @@ func GitLoginAction(w http.ResponseWriter, r *http.Request) error {
 	session.Values["Token"] = nil
 	session.Values["version"] = version
 	redirect := r.FormValue("redirect")
+	delete(session.Values, "Redirect")
 	if redirect != "" && len(redirect) < 2048 {
 		session.Values["Redirect"] = redirect
 	}
@@ -314,6 +315,7 @@ func SqlLoginAction(w http.ResponseWriter, r *http.Request) error {
 	session.Values["Token"] = nil
 	session.Values["version"] = version
 	redirect := r.FormValue("redirect")
+	delete(session.Values, "Redirect")
 	if redirect != "" && len(redirect) < 2048 {
 		session.Values["Redirect"] = redirect
 	}

--- a/cmd/gobookmarks/serve_test.go
+++ b/cmd/gobookmarks/serve_test.go
@@ -1,40 +1,186 @@
 package main
 
 import (
+	"context"
+	"github.com/arran4/gobookmarks"
+	"github.com/gorilla/sessions"
+	"golang.org/x/oauth2"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-// We verify the compatibility route caching headers directly using an HTTP test rather than trying
-// to start the full `serve` command.
-func TestCompatibilityRouteCacheHeaders(t *testing.T) {
-	// setupRouter builds the production router exactly as the serve command uses it
-	r := setupRouter()
+type mockRoundTripper struct{}
 
-	// Test /main.css
-	reqCSS := httptest.NewRequest("GET", "/main.css", nil)
-	recCSS := httptest.NewRecorder()
-	r.ServeHTTP(recCSS, reqCSS)
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.String(), "access_token") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"mocktoken","token_type":"bearer"}`)),
+		}, nil
+	}
+	if strings.Contains(req.URL.String(), "user") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"login":"mockuser"}`)),
+		}, nil
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
 
-	if recCSS.Header().Get("Cache-Control") != "no-cache" {
-		t.Errorf("expected Cache-Control: no-cache on /main.css, got %q", recCSS.Header().Get("Cache-Control"))
+func TestRedirectToHandlerIntegration(t *testing.T) {
+	// Initialize minimal configuration
+	gobookmarks.Config.SessionName = "testsess"
+	gobookmarks.SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	// 1. Simulate setting up a successful session with Redirect set
+	req := httptest.NewRequest("GET", "/login", nil)
+	session, _ := gobookmarks.SessionStore.Get(req, gobookmarks.Config.GetSessionName())
+	session.Values["Redirect"] = "/tab/2?page=3"
+
+	w := httptest.NewRecorder()
+	_ = session.Save(req, w)
+
+	// We create a new request simulating the next step in the chain where `redirectToHandler("/")` is executed
+	req2 := httptest.NewRequest("GET", "/some_callback_path", nil)
+	// Add the session cookie so redirectToHandler finds it
+	for _, cookie := range w.Result().Cookies() {
+		if cookie.MaxAge > 0 {
+			req2.AddCookie(cookie)
+		}
 	}
 
-	if recCSS.Code != http.StatusFound && recCSS.Code != http.StatusOK {
-		t.Errorf("expected status 302 or 200 on /main.css, got %d", recCSS.Code)
+	w2 := httptest.NewRecorder()
+
+	// Execute redirectToHandler directly
+	handler := redirectToHandler("/")
+	handler(w2, req2)
+
+	loc := w2.Result().Header.Get("Location")
+	if loc != "/tab/2?page=3" {
+		t.Fatalf("Expected redirectToHandler to consume session Redirect and point to /tab/2?page=3, got: %s", loc)
+	}
+}
+
+func TestFullLoginChainIntegration(t *testing.T) {
+	gobookmarks.Config.SessionName = "testsess"
+	gobookmarks.SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	d := t.TempDir()
+	gobookmarks.Config.LocalGitPath = d
+	gobookmarks.Config.DBConnectionProvider = "sqlite3"
+	gobookmarks.Config.DBConnectionString = d + "/test.db"
+	gobookmarks.RegisterProvider(&gobookmarks.GitProvider{})
+	gobookmarks.RegisterProvider(&gobookmarks.SQLProvider{})
+
+	// 1. Simulate a successful Git signup
+	req := httptest.NewRequest("POST", "/signup/git", strings.NewReader("username=bob&password=secret&redirect=/tab/2?page=3"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	session, _ := gobookmarks.SessionStore.Get(req, gobookmarks.Config.GetSessionName())
+	gobookmarks.SetVersion("vtest", "c", "d")
+	session.Values["version"] = "vtest"
+	ctx := context.WithValue(req.Context(), gobookmarks.ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	handlerSignupGit := runHandlerChain(gobookmarks.GitSignupAction, redirectToHandler("/login/git"))
+	handlerSignupGit(w, req)
+
+	loc := w.Result().Header.Get("Location")
+	if loc != "/login/git?redirect=%2Ftab%2F2%3Fpage%3D3" {
+		t.Fatalf("Expected git signup to redirect to /login/git?redirect=%%2Ftab%%2F2%%3Fpage%%3D3, got: %s", loc)
 	}
 
-	// Test /favicon.ico
-	reqFavicon := httptest.NewRequest("GET", "/favicon.ico", nil)
-	recFavicon := httptest.NewRecorder()
-	r.ServeHTTP(recFavicon, reqFavicon)
+	// 2. Simulate a successful Git login via chain
+	req2 := httptest.NewRequest("POST", "/login/git", strings.NewReader("username=bob&password=secret&redirect=/tab/2?page=3"))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w2 := httptest.NewRecorder()
 
-	if recFavicon.Header().Get("Cache-Control") != "no-cache" {
-		t.Errorf("expected Cache-Control: no-cache on /favicon.ico, got %q", recFavicon.Header().Get("Cache-Control"))
+	for _, cookie := range w.Result().Cookies() {
+		if cookie.MaxAge > 0 {
+			req2.AddCookie(cookie)
+		}
+	}
+	session2, _ := gobookmarks.SessionStore.Get(req2, gobookmarks.Config.GetSessionName())
+	session2.Values["version"] = "vtest"
+	ctx2 := context.WithValue(req2.Context(), gobookmarks.ContextValues("session"), session2)
+	req2 = req2.WithContext(ctx2)
+
+	handlerLoginGit := runHandlerChain(gobookmarks.GitLoginAction, redirectToHandler("/"))
+	handlerLoginGit(w2, req2)
+
+	loc2 := w2.Result().Header.Get("Location")
+	if loc2 != "/tab/2?page=3" {
+		t.Fatalf("Expected git login to eventually redirect to /tab/2?page=3 via redirectToHandler, got: %s", loc2)
 	}
 
-	if recFavicon.Code != http.StatusFound && recFavicon.Code != http.StatusOK {
-		t.Errorf("expected status 302 or 200 on /favicon.ico, got %d", recFavicon.Code)
+	// 3. Simulate a successful SQL signup
+	req3 := httptest.NewRequest("POST", "/signup/sql", strings.NewReader("username=sue&password=secret&redirect=/tab/2?page=3"))
+	req3.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w3 := httptest.NewRecorder()
+
+	session3, _ := gobookmarks.SessionStore.Get(req3, gobookmarks.Config.GetSessionName())
+	session3.Values["version"] = "vtest"
+	ctx3 := context.WithValue(req3.Context(), gobookmarks.ContextValues("session"), session3)
+	req3 = req3.WithContext(ctx3)
+
+	handlerSignupSql := runHandlerChain(gobookmarks.SqlSignupAction, redirectToHandler("/login/sql"))
+	handlerSignupSql(w3, req3)
+
+	loc3 := w3.Result().Header.Get("Location")
+	if loc3 != "/login/sql?redirect=%2Ftab%2F2%3Fpage%3D3" {
+		t.Fatalf("Expected sql signup to redirect to /login/sql?redirect=%%2Ftab%%2F2%%3Fpage%%3D3, got: %s", loc3)
+	}
+
+	// 4. Simulate a successful SQL login via chain
+	req4 := httptest.NewRequest("POST", "/login/sql", strings.NewReader("username=sue&password=secret&redirect=/tab/2?page=3"))
+	req4.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w4 := httptest.NewRecorder()
+
+	for _, cookie := range w3.Result().Cookies() {
+		if cookie.MaxAge > 0 {
+			req4.AddCookie(cookie)
+		}
+	}
+	session4, _ := gobookmarks.SessionStore.Get(req4, gobookmarks.Config.GetSessionName())
+	session4.Values["version"] = "vtest"
+	ctx4 := context.WithValue(req4.Context(), gobookmarks.ContextValues("session"), session4)
+	req4 = req4.WithContext(ctx4)
+
+	handlerLoginSql := runHandlerChain(gobookmarks.SqlLoginAction, redirectToHandler("/"))
+	handlerLoginSql(w4, req4)
+
+	loc4 := w4.Result().Header.Get("Location")
+	if loc4 != "/tab/2?page=3" {
+		t.Fatalf("Expected sql login to eventually redirect to /tab/2?page=3 via redirectToHandler, got: %s", loc4)
+	}
+
+	// 5. Simulate Oauth callback success via chain
+	req5 := httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3&code=mockcode", nil)
+	w5 := httptest.NewRecorder()
+
+	session5, _ := gobookmarks.SessionStore.Get(req5, gobookmarks.Config.GetSessionName())
+	session5.Values["version"] = "vtest"
+
+	client := &http.Client{Transport: &mockRoundTripper{}}
+	ctx5 := context.WithValue(req5.Context(), oauth2.HTTPClient, client)
+	ctx5 = context.WithValue(ctx5, gobookmarks.ContextValues("session"), session5)
+	req5 = req5.WithContext(ctx5)
+
+	gobookmarks.Config.GithubClientID = "id"
+	gobookmarks.Config.GithubSecret = "secret"
+	gobookmarks.RegisterProvider(&gobookmarks.GitHubProvider{})
+
+	handlerOauth := runHandlerChain(gobookmarks.Oauth2CallbackPage, redirectToHandler("/"))
+	handlerOauth(w5, req5)
+
+	loc5 := w5.Result().Header.Get("Location")
+	if loc5 != "/tab/2?page=3" {
+		t.Fatalf("Expected oauth callback to eventually redirect to /tab/2?page=3 via redirectToHandler, got: %s", loc5)
 	}
 }

--- a/cmd/gobookmarks/serve_test.go
+++ b/cmd/gobookmarks/serve_test.go
@@ -184,3 +184,36 @@ func TestFullLoginChainIntegration(t *testing.T) {
 		t.Fatalf("Expected oauth callback to eventually redirect to /tab/2?page=3 via redirectToHandler, got: %s", loc5)
 	}
 }
+
+// We verify the compatibility route caching headers directly using an HTTP test rather than trying
+// to start the full `serve` command.
+func TestCompatibilityRouteCacheHeaders(t *testing.T) {
+	// setupRouter builds the production router exactly as the serve command uses it
+	r := setupRouter()
+
+	// Test /main.css
+	reqCSS := httptest.NewRequest("GET", "/main.css", nil)
+	recCSS := httptest.NewRecorder()
+	r.ServeHTTP(recCSS, reqCSS)
+
+	if recCSS.Header().Get("Cache-Control") != "no-cache" {
+		t.Errorf("expected Cache-Control: no-cache on /main.css, got %q", recCSS.Header().Get("Cache-Control"))
+	}
+
+	if recCSS.Code != http.StatusFound && recCSS.Code != http.StatusOK {
+		t.Errorf("expected status 302 or 200 on /main.css, got %d", recCSS.Code)
+	}
+
+	// Test /favicon.ico
+	reqFavicon := httptest.NewRequest("GET", "/favicon.ico", nil)
+	recFavicon := httptest.NewRecorder()
+	r.ServeHTTP(recFavicon, reqFavicon)
+
+	if recFavicon.Header().Get("Cache-Control") != "no-cache" {
+		t.Errorf("expected Cache-Control: no-cache on /favicon.ico, got %q", recFavicon.Header().Get("Cache-Control"))
+	}
+
+	if recFavicon.Code != http.StatusFound && recFavicon.Code != http.StatusOK {
+		t.Errorf("expected status 302 or 200 on /favicon.ico, got %d", recFavicon.Code)
+	}
+}

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -1,8 +1,11 @@
 package gobookmarks
 
 import (
+	"context"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
+	"golang.org/x/oauth2"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,24 +24,7 @@ func TestLoginRouteProviderVariable(t *testing.T) {
 	Config.ExternalURL = "http://example.com/"
 
 	r := mux.NewRouter()
-	r.HandleFunc("/login/{provider
-	// Test the Oauth2CallbackPage to ensure it extracts the redirect properly from the state parameter
-	req = httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3", nil)
-	w = httptest.NewRecorder()
-
-	session, _ := SessionStore.Get(req, Config.GetSessionName())
-	session.Values["version"] = version
-	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
-	req = req.WithContext(ctx)
-
-	// Note: Oauth2CallbackPage actually exchanges the token. Without a real server, it will fail: "exchange error".
-	// But it sets session.Values["Redirect"] BEFORE failing!
-	_ = Oauth2CallbackPage(w, req)
-
-	if session.Values["Redirect"] != "/tab/2?page=3" {
-		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v", session.Values["Redirect"])
-	}
-}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
+	r.HandleFunc("/login/{provider}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
 
 	req := httptest.NewRequest("GET", "/login/github", nil)
 	w := httptest.NewRecorder()
@@ -114,6 +100,28 @@ func TestLoginRouteProviderVariableRedirect(t *testing.T) {
 	}
 }
 
+type mockRoundTripper struct{}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If it's a token exchange, return a dummy token
+	if strings.Contains(req.URL.String(), "access_token") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"mocktoken","token_type":"bearer"}`)),
+		}, nil
+	}
+	// If it's fetching the user, return a dummy user
+	if strings.Contains(req.URL.String(), "user") {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"login":"mockuser"}`)),
+		}, nil
+	}
+	return http.DefaultTransport.RoundTrip(req)
+}
+
 func TestOauth2CallbackRedirect(t *testing.T) {
 	Config.SessionName = "testsess"
 	SessionStore = sessions.NewCookieStore([]byte("secret"))
@@ -124,20 +132,43 @@ func TestOauth2CallbackRedirect(t *testing.T) {
 	Config.GitlabSecret = "secret"
 	Config.ExternalURL = "http://example.com/"
 
+	// Set up the mock client
+	client := &http.Client{Transport: &mockRoundTripper{}}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+
 	// Test the Oauth2CallbackPage to ensure it extracts the redirect properly from the state parameter
-	req := httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3", nil)
+	req := httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3&code=mockcode", nil)
 	w := httptest.NewRecorder()
 
 	session, _ := SessionStore.Get(req, Config.GetSessionName())
 	session.Values["version"] = version
-	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	ctx = context.WithValue(ctx, ContextValues("session"), session)
 	req = req.WithContext(ctx)
 
-	// Note: Oauth2CallbackPage actually exchanges the token. Without a real server, it will fail: "exchange error".
-	// But it sets session.Values["Redirect"] BEFORE failing!
-	_ = Oauth2CallbackPage(w, req)
+	// Since we mocked the token exchange and user fetching, Oauth2CallbackPage should succeed and return nil
+	err := Oauth2CallbackPage(w, req)
+	if err != nil {
+		t.Fatalf("Oauth2CallbackPage failed: %v", err)
+	}
 
-	if session.Values["Redirect"] != "/tab/2?page=3" {
-		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v", session.Values["Redirect"])
+	// Read the new session from the response cookies
+	req2 := httptest.NewRequest("GET", "/", nil)
+	cookies := w.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("No cookies returned from Oauth2CallbackPage!")
+	}
+	// Add only the valid cookie (the last one or the one with Max-Age > 0)
+	for _, cookie := range cookies {
+		if cookie.MaxAge > 0 {
+			req2.AddCookie(cookie)
+		}
+	}
+	session2, err2 := SessionStore.Get(req2, Config.GetSessionName())
+	if err2 != nil {
+		t.Logf("SessionStore.Get error: %v", err2)
+	}
+
+	if session2.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v (All values: %v)", session2.Values["Redirect"], session2.Values)
 	}
 }

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -60,3 +60,39 @@ func TestLoginRouteProviderVariable(t *testing.T) {
 		t.Fatalf("expected 404 for unknown provider, got %d", w.Result().StatusCode)
 	}
 }
+
+func TestLoginRouteProviderVariableRedirect(t *testing.T) {
+	Config.SessionName = "testsess"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+	version = "vtest"
+	Config.GithubClientID = "id"
+	Config.GithubSecret = "secret"
+	Config.GitlabClientID = "id"
+	Config.GitlabSecret = "secret"
+	Config.ExternalURL = "http://example.com/"
+
+	r := mux.NewRouter()
+	r.HandleFunc("/login/{provider}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
+
+	req := httptest.NewRequest("GET", "/login/github?redirect=%2Ftab%2F2", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	parsed, err := url.Parse(w.Result().Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse OAuth redirect with explicit return URL: %v", err)
+	}
+	if state := parsed.Query().Get("state"); state != "github:/tab/2" {
+		t.Fatalf("explicit redirect must be included in OAuth state, got %q", state)
+	}
+
+	req = httptest.NewRequest("GET", "/login/github?redirect=%2Ftab%2F2%3Fpage%3D3", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	parsed, err = url.Parse(w.Result().Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("parse OAuth redirect with explicit complex return URL: %v", err)
+	}
+	if state := parsed.Query().Get("state"); state != "github:/tab/2?page=3" {
+		t.Fatalf("explicit complex redirect must be included in OAuth state, got %q", state)
+	}
+}

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -21,7 +21,24 @@ func TestLoginRouteProviderVariable(t *testing.T) {
 	Config.ExternalURL = "http://example.com/"
 
 	r := mux.NewRouter()
-	r.HandleFunc("/login/{provider}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
+	r.HandleFunc("/login/{provider
+	// Test the Oauth2CallbackPage to ensure it extracts the redirect properly from the state parameter
+	req = httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3", nil)
+	w = httptest.NewRecorder()
+
+	session, _ := SessionStore.Get(req, Config.GetSessionName())
+	session.Values["version"] = version
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	// Note: Oauth2CallbackPage actually exchanges the token. Without a real server, it will fail: "exchange error".
+	// But it sets session.Values["Redirect"] BEFORE failing!
+	_ = Oauth2CallbackPage(w, req)
+
+	if session.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v", session.Values["Redirect"])
+	}
+}", func(w http.ResponseWriter, r *http.Request) { _ = LoginWithProvider(w, r) }).Methods("GET")
 
 	req := httptest.NewRequest("GET", "/login/github", nil)
 	w := httptest.NewRecorder()
@@ -94,5 +111,33 @@ func TestLoginRouteProviderVariableRedirect(t *testing.T) {
 	}
 	if state := parsed.Query().Get("state"); state != "github:/tab/2?page=3" {
 		t.Fatalf("explicit complex redirect must be included in OAuth state, got %q", state)
+	}
+}
+
+func TestOauth2CallbackRedirect(t *testing.T) {
+	Config.SessionName = "testsess"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+	version = "vtest"
+	Config.GithubClientID = "id"
+	Config.GithubSecret = "secret"
+	Config.GitlabClientID = "id"
+	Config.GitlabSecret = "secret"
+	Config.ExternalURL = "http://example.com/"
+
+	// Test the Oauth2CallbackPage to ensure it extracts the redirect properly from the state parameter
+	req := httptest.NewRequest("GET", "/oauth2Callback?state=github:/tab/2?page=3", nil)
+	w := httptest.NewRecorder()
+
+	session, _ := SessionStore.Get(req, Config.GetSessionName())
+	session.Values["version"] = version
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	// Note: Oauth2CallbackPage actually exchanges the token. Without a real server, it will fail: "exchange error".
+	// But it sets session.Values["Redirect"] BEFORE failing!
+	_ = Oauth2CallbackPage(w, req)
+
+	if session.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v", session.Values["Redirect"])
 	}
 }

--- a/login_handler_test.go
+++ b/login_handler_test.go
@@ -152,7 +152,7 @@ func TestOauth2CallbackRedirect(t *testing.T) {
 	}
 
 	// Read the new session from the response cookies
-	req2 := httptest.NewRequest("GET", "/", nil)
+	req2_check := httptest.NewRequest("GET", "/", nil)
 	cookies := w.Result().Cookies()
 	if len(cookies) == 0 {
 		t.Fatalf("No cookies returned from Oauth2CallbackPage!")
@@ -160,10 +160,10 @@ func TestOauth2CallbackRedirect(t *testing.T) {
 	// Add only the valid cookie (the last one or the one with Max-Age > 0)
 	for _, cookie := range cookies {
 		if cookie.MaxAge > 0 {
-			req2.AddCookie(cookie)
+			req2_check.AddCookie(cookie)
 		}
 	}
-	session2, err2 := SessionStore.Get(req2, Config.GetSessionName())
+	session2, err2 := SessionStore.Get(req2_check, Config.GetSessionName())
 	if err2 != nil {
 		t.Logf("SessionStore.Get error: %v", err2)
 	}
@@ -171,4 +171,6 @@ func TestOauth2CallbackRedirect(t *testing.T) {
 	if session2.Values["Redirect"] != "/tab/2?page=3" {
 		t.Fatalf("Expected Oauth2CallbackPage to set session Redirect to /tab/2?page=3, got: %v (All values: %v)", session2.Values["Redirect"], session2.Values)
 	}
+
+
 }

--- a/signup_git_http_test.go
+++ b/signup_git_http_test.go
@@ -189,11 +189,21 @@ func TestGitSignupScenarioWithRedirect(t *testing.T) {
 	req = httptest.NewRequest("POST", "/login/git", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w = httptest.NewRecorder()
+
+	// Create context with session
+	session, _ := SessionStore.Get(req, Config.GetSessionName())
+	// Set version to avoid getSession clearing it!
+	session.Values["version"] = version
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
 	if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 
-
+	if session.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected session redirect to be set to /tab/2?page=3, got: %v", session.Values["Redirect"])
+	}
 
 	// Login failure
 	form = url.Values{"username": []string{"bob"}, "password": []string{"wrong"}, "redirect": []string{"/tab/2?page=3"}}

--- a/signup_git_http_test.go
+++ b/signup_git_http_test.go
@@ -24,7 +24,7 @@ func TestGitSignupScenario(t *testing.T) {
 	req := httptest.NewRequest("POST", "/signup/git", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
-	if err := GitSignupAction(w, req); err != nil {
+		if err := GitSignupAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("signup action: %v", err)
 	}
 	if _, err := os.Stat(passwordPath("alice")); err != nil {
@@ -47,7 +47,7 @@ func TestGitSignupScenario(t *testing.T) {
 	req = httptest.NewRequest("POST", "/login/git", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w = httptest.NewRecorder()
-	if err := GitLoginAction(w, req); err != nil {
+		if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 	cookies := w.Result().Cookies()
@@ -138,7 +138,7 @@ func TestGitLoginIgnoresInvalidSession(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: Config.SessionName, Value: "invalid"})
 
 	w := httptest.NewRecorder()
-	if err := GitLoginAction(w, req); err != nil {
+		if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 	cookies := w.Result().Cookies()

--- a/signup_git_http_test.go
+++ b/signup_git_http_test.go
@@ -24,7 +24,7 @@ func TestGitSignupScenario(t *testing.T) {
 	req := httptest.NewRequest("POST", "/signup/git", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
-		if err := GitSignupAction(w, req); err != nil && err != ErrHandled {
+	if err := GitSignupAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("signup action: %v", err)
 	}
 	if _, err := os.Stat(passwordPath("alice")); err != nil {
@@ -47,7 +47,7 @@ func TestGitSignupScenario(t *testing.T) {
 	req = httptest.NewRequest("POST", "/login/git", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w = httptest.NewRecorder()
-		if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
+	if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 	cookies := w.Result().Cookies()
@@ -138,7 +138,7 @@ func TestGitLoginIgnoresInvalidSession(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: Config.SessionName, Value: "invalid"})
 
 	w := httptest.NewRecorder()
-		if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
+	if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 	cookies := w.Result().Cookies()
@@ -147,5 +147,65 @@ func TestGitLoginIgnoresInvalidSession(t *testing.T) {
 	}
 	if cookies[len(cookies)-1].Value == "invalid" {
 		t.Fatalf("session cookie not replaced")
+	}
+}
+
+func TestGitSignupScenarioWithRedirect(t *testing.T) {
+	d := t.TempDir()
+	Config.LocalGitPath = d
+
+	Config.SessionName = "testsess"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	// signup
+	form := url.Values{"username": []string{"bob"}, "password": []string{"secret"}, "redirect": []string{"/tab/2"}}
+	req := httptest.NewRequest("POST", "/signup/git", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	if err := GitSignupAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("signup action: %v", err)
+	}
+
+	loc := w.Result().Header.Get("Location")
+	if loc != "/login/git?redirect=%2Ftab%2F2" {
+		t.Fatalf("Expected redirect to login page with preserved redirect, got: %s", loc)
+	}
+
+	// Sign up again to trigger error
+	req = httptest.NewRequest("POST", "/signup/git", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	if err := GitSignupAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("signup action error: %v", err)
+	}
+
+	loc = w.Result().Header.Get("Location")
+	if loc != "/login/git?error=exists&redirect=%2Ftab%2F2" {
+		t.Fatalf("Expected redirect to login page with preserved error and redirect, got: %s", loc)
+	}
+
+	// Login successfully
+	form = url.Values{"username": []string{"bob"}, "password": []string{"secret"}, "redirect": []string{"/tab/2?page=3"}}
+	req = httptest.NewRequest("POST", "/login/git", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("login action: %v", err)
+	}
+
+
+
+	// Login failure
+	form = url.Values{"username": []string{"bob"}, "password": []string{"wrong"}, "redirect": []string{"/tab/2?page=3"}}
+	req = httptest.NewRequest("POST", "/login/git", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	if err := GitLoginAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("login action: %v", err)
+	}
+
+	loc = w.Result().Header.Get("Location")
+	if loc != "/login/git?error=invalid&redirect=%2Ftab%2F2%3Fpage%3D3" {
+		t.Fatalf("Expected redirect to login page with preserved error and redirect, got: %s", loc)
 	}
 }

--- a/sql_login_test.go
+++ b/sql_login_test.go
@@ -1,8 +1,7 @@
 package gobookmarks
 
 import (
-	"context"
-	"github.com/gorilla/sessions"
+		"github.com/gorilla/sessions"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -17,7 +16,7 @@ func TestSqlSignupScenarioWithRedirect(t *testing.T) {
 	dbFile := d + "/test.db"
 	f, err := os.Create(dbFile)
 	if err == nil {
-		f.Close()
+		_ = f.Close()
 	}
 
 	Config.DBConnectionProvider = "sqlite3"
@@ -59,20 +58,31 @@ func TestSqlSignupScenarioWithRedirect(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w = httptest.NewRecorder()
 
-	// Create context with session
-	session, _ := SessionStore.Get(req, Config.GetSessionName())
-	// Set version to avoid getSession clearing it!
-	session.Values["version"] = version
-	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
-	req = req.WithContext(ctx)
-
 	if err := SqlLoginAction(w, req); err != nil && err != ErrHandled {
 		t.Fatalf("login action: %v", err)
 	}
 
-	if session.Values["Redirect"] != "/tab/2?page=3" {
-		t.Fatalf("Expected session redirect to be set to /tab/2?page=3, got: %v", session.Values["Redirect"])
+	// Read the new session from the response cookies
+	req2_check := httptest.NewRequest("GET", "/", nil)
+	cookies := w.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("No cookies returned from SqlLoginAction!")
 	}
+	for _, cookie := range cookies {
+		if cookie.MaxAge > 0 {
+			req2_check.AddCookie(cookie)
+		}
+	}
+	session2, err2 := SessionStore.Get(req2_check, Config.GetSessionName())
+	if err2 != nil {
+		t.Logf("SessionStore.Get error: %v", err2)
+	}
+
+	if session2.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected session redirect to be set to /tab/2?page=3, got: %v", session2.Values["Redirect"])
+	}
+
+
 
 	// Login failure
 	form = url.Values{"username": []string{"bob"}, "password": []string{"wrong"}, "redirect": []string{"/tab/2?page=3"}}

--- a/sql_login_test.go
+++ b/sql_login_test.go
@@ -1,0 +1,90 @@
+package gobookmarks
+
+import (
+	"context"
+	"github.com/gorilla/sessions"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSqlSignupScenarioWithRedirect(t *testing.T) {
+	d := t.TempDir()
+
+	// Create an empty db file to prevent errors
+	dbFile := d + "/test.db"
+	f, err := os.Create(dbFile)
+	if err == nil {
+		f.Close()
+	}
+
+	Config.DBConnectionProvider = "sqlite3"
+	Config.DBConnectionString = dbFile
+
+	Config.SessionName = "testsess"
+	SessionStore = sessions.NewCookieStore([]byte("secret"))
+
+	// signup
+	form := url.Values{"username": []string{"bob"}, "password": []string{"secret"}, "redirect": []string{"/tab/2"}}
+	req := httptest.NewRequest("POST", "/signup/sql", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	if err := SqlSignupAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("signup action: %v", err)
+	}
+
+	loc := w.Result().Header.Get("Location")
+	if loc != "/login/sql?redirect=%2Ftab%2F2" {
+		t.Fatalf("Expected redirect to login page with preserved redirect, got: %s", loc)
+	}
+
+	// Sign up again to trigger error
+	req = httptest.NewRequest("POST", "/signup/sql", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	if err := SqlSignupAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("signup action error: %v", err)
+	}
+
+	loc = w.Result().Header.Get("Location")
+	if loc != "/login/sql?error=exists&redirect=%2Ftab%2F2" {
+		t.Fatalf("Expected redirect to login page with preserved error and redirect, got: %s", loc)
+	}
+
+	// Login successfully
+	form = url.Values{"username": []string{"bob"}, "password": []string{"secret"}, "redirect": []string{"/tab/2?page=3"}}
+	req = httptest.NewRequest("POST", "/login/sql", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+
+	// Create context with session
+	session, _ := SessionStore.Get(req, Config.GetSessionName())
+	// Set version to avoid getSession clearing it!
+	session.Values["version"] = version
+	ctx := context.WithValue(req.Context(), ContextValues("session"), session)
+	req = req.WithContext(ctx)
+
+	if err := SqlLoginAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("login action: %v", err)
+	}
+
+	if session.Values["Redirect"] != "/tab/2?page=3" {
+		t.Fatalf("Expected session redirect to be set to /tab/2?page=3, got: %v", session.Values["Redirect"])
+	}
+
+	// Login failure
+	form = url.Values{"username": []string{"bob"}, "password": []string{"wrong"}, "redirect": []string{"/tab/2?page=3"}}
+	req = httptest.NewRequest("POST", "/login/sql", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	if err := SqlLoginAction(w, req); err != nil && err != ErrHandled {
+		t.Fatalf("login action: %v", err)
+	}
+
+	loc = w.Result().Header.Get("Location")
+	if loc != "/login/sql?error=invalid&redirect=%2Ftab%2F2%3Fpage%3D3" {
+		t.Fatalf("Expected redirect to login page with preserved error and redirect, got: %s", loc)
+	}
+}


### PR DESCRIPTION
Fixes a bug where completing a login flow drops the user at the homepage instead of preserving the `redirect` destination they originally navigated from. Validated against local SQL/Git authentication, and mocked OAuth callbacks. Fixes superfluous `WriteHeader` logs that occurred due to chained handlers executing after a redirect.

---
*PR created automatically by Jules for task [17913060990008657499](https://jules.google.com/task/17913060990008657499) started by @arran4*