### PR TITLE
Fix dynamic title update on tab switch

### DIFF
--- a/templates/head.gohtml
+++ b/templates/head.gohtml
@@ -2,6 +2,7 @@
 <html>
 	<head>
                 <title>{{$.Title}}{{ $tname := tabName }}{{ if $tname }}: {{ $tname }}{{ end }}</title>
+                <meta name="base-title" content="{{$.Title}}">
 		<style type="text/css">
         <!--
         @import url("{{ asset "main.css" }}");

--- a/templates/tail.gohtml
+++ b/templates/tail.gohtml
@@ -247,6 +247,17 @@
                     setTimeout(jumpToHash, 50);
 
                     function setActiveTab(tabIdx) {
+                        var baseTitle = document.querySelector("meta[name=\x27base-title\x27]") ? document.querySelector("meta[name=\x27base-title\x27]").content : "";
+                        var tabName = "";
+                        var activeTabEl = document.querySelector(".tab-panel[data-tab-index=\x27" + tabIdx + "\x27]");
+                        if (activeTabEl) {
+                            tabName = activeTabEl.dataset.tabName || "";
+                        }
+                        if (tabName) {
+                            document.title = baseTitle + ": " + tabName;
+                        } else {
+                            document.title = baseTitle;
+                        }
                         currentTabIndex = tabIdx;
                         searchMode = false;
                         if (!tabContent) return;


### PR DESCRIPTION
Added a `<meta name="base-title">` tag to `head.gohtml` to inject the server-configured title text. Modified `setActiveTab` in `tail.gohtml` to read this meta tag and combine it with the selected tab's name, accurately setting `document.title` on client-side navigation.

---
*PR created automatically by Jules for task [8367375895859105784](https://jules.google.com/task/8367375895859105784) started by @arran4*